### PR TITLE
test(clube.controller): cobre cenários de busca paginada, busca por id e exceção na controller de clubes

### DIFF
--- a/anotacoes-teste.md
+++ b/anotacoes-teste.md
@@ -1,0 +1,53 @@
+Com seu exemplo de código e modelo de documentação, aqui está como documentar **de forma sucinta, objetiva e focada só no código, argumentos e lógica** (e não em como rodar/comandos):
+
+---
+
+# Anotações
+
+## Clube
+
+### 1. **Buscar clube controller (GET - todos com Page, por id, e exceção)**
+
+#### **Descrição técnica**
+Foram implementados testes unitários para o controller responsável por buscar clubes de futebol.  
+A classe `BuscarClubeApiControllerTest` cobre os cenários principais de busca paginada (com filtros opcionais na query), busca por id e cenário de exceção (clube não encontrado).
+
+#### **Métodos de teste**
+- `deveBuscarTodosClubesComSucesso(String nome, String estado, Boolean ativo)`
+    - Testa o endpoint de busca paginada de clubes (`/api/clube/buscar`)
+    - Utiliza argumentos opcionais (`nome`, `estado`, `ativo`) via `@CsvSource`, incluindo variações com filtros nulos ou preenchidos.
+    - Espera resposta em formato paginado (Page), verifica tamanho da lista retornada e campos específicos do DTO via `jsonPath`.
+
+- `deveBuscarClubePorIdComSucesso()`
+    - Testa o endpoint de busca por id (`/api/clube/buscar/{id}`).
+    - Argumento: `id` do clube a ser buscado.
+    - Simula retorno do clube via mock do service, verifica os campos do DTO no JSON de resposta (incluindo serialização da data em array).
+
+- `deveRetornarNotFoundQuandoClubeNaoExistir()`
+    - Testa o cenário de exceção ao buscar clube por id inexistente.
+    - Argumento: `id` inexistente.
+    - Simula exceção no service (`ClubeNaoEncontradoException`).
+    - Valida o status HTTP 404 retornado.
+
+#### **Principais argumentos e dependências**
+- **Controllers/Endpoints testados:**
+    - `/api/clube/buscar [GET]` (paginado, filtros opcionais)
+    - `/api/clube/buscar/{id} [GET]`
+- **Parâmetros opcionais:** `nome`, `estado`, `ativo`, além de parâmetros de paginação (`page`, `size`)
+- **Resolução de Pageable** via `PageableHandlerMethodArgumentResolver` no setup do MockMvc
+- **Uso de `any()` nos argumentos do Mockito** para abranger todos os cenários de filtros
+- **DTO de resposta**: `ClubeResponseDTO` com campos `nome`, `siglaEstado`, `dataCriacao`
+- **Verificação detalhada do JSON** usando `jsonPath`, especialmente para datas
+- **Mock dos services** com Mockito para simular cenários de sucesso e exceção
+- **ControllerAdvice** incluído no setup para tratamento global e específico de exceções de clube
+
+#### **Checklist de implementação**
+- [x] Testes para busca paginada com filtros opcionais e parâmetros de página.
+- [x] Teste para busca por id (sucesso).
+- [x] Teste para retorno de exceção 404 (clube não encontrado).
+- [x] Todos os campos relevantes do DTO verificados no JSON (`nome`, `siglaEstado`, `dataCriacao` como array).
+- [x] Uso de lista mutável (`new ArrayList<>`) no PageImpl, garantindo serialização correta com Jackson.
+- [x] Setup do MockMvc inclui ControllerAdvices e ArgumentResolver para Pageable.
+- [x] Impressão do início de cada teste via `PrintUtil`.
+
+---

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
-spring.profiles.active=dev
+spring.profiles.active=test
 server.port=8080

--- a/src/test/java/br/com/meli/teamcubation_partidas_de_futebol/clube/BuscarClubeApiControllerTest.java
+++ b/src/test/java/br/com/meli/teamcubation_partidas_de_futebol/clube/BuscarClubeApiControllerTest.java
@@ -1,0 +1,143 @@
+package br.com.meli.teamcubation_partidas_de_futebol.clube;
+
+import br.com.meli.teamcubation_partidas_de_futebol.clube.controller.BuscarClubeApiController;
+import br.com.meli.teamcubation_partidas_de_futebol.clube.dto.ClubeResponseDTO;
+import br.com.meli.teamcubation_partidas_de_futebol.clube.dto.mapper.ClubeResponseMapper;
+import br.com.meli.teamcubation_partidas_de_futebol.clube.exception.ClubeApiExceptionHandler;
+import br.com.meli.teamcubation_partidas_de_futebol.clube.exception.ClubeNaoEncontradoException;
+import br.com.meli.teamcubation_partidas_de_futebol.clube.model.Clube;
+import br.com.meli.teamcubation_partidas_de_futebol.clube.service.BuscarClubeService;
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.GlobalApiExceptionHandler;
+import br.com.meli.teamcubation_partidas_de_futebol.util.PrintUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ExtendWith(MockitoExtension.class)
+public class BuscarClubeApiControllerTest {
+    @InjectMocks
+    BuscarClubeApiController buscarClubeApiController;
+    @Mock
+    BuscarClubeService buscarClubeService;
+
+    MockMvc mockMvc;
+
+    final String PATH = "/api/clube/buscar";
+    final String PATH_COM_ID = "/api/clube/buscar/{id}";
+
+    @BeforeEach
+    public void setUp(TestInfo testeInfo) {
+        PrintUtil.printInicioDoTeste(testeInfo.getDisplayName());
+        mockMvc = MockMvcBuilders.standaloneSetup(buscarClubeApiController)
+                .setControllerAdvice(new GlobalApiExceptionHandler(), new ClubeApiExceptionHandler())
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .build();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            ",,",
+            "clube de time,,",
+            ",sp,",
+            ",,true",
+            "clube de time,sp,true"
+    })
+    void deveBuscarTodosClubesComSucesso(String nome, String estado, Boolean ativo) throws Exception {
+        ClubeResponseDTO dto1 = new ClubeResponseDTO("clube de time", "sp", LocalDate.of(2025,11,3));
+        ClubeResponseDTO dto2 = new ClubeResponseDTO("clube de time", "am", LocalDate.of(2025,11,3));
+
+        Page<ClubeResponseDTO> clubesRetornados = new PageImpl<>(new ArrayList<>(List.of(dto1, dto2)),
+                org.springframework.data.domain.PageRequest.of(0, 10),
+                2L);
+
+
+        Mockito.when(buscarClubeService.listarClubesFiltrados(
+                any(), any(), any(), any(Pageable.class)
+        )).thenReturn(clubesRetornados);
+
+        var requestBuilder = get(PATH)
+                .param("page", "0")
+                .param("size", "10")
+                .contentType(MediaType.APPLICATION_JSON);
+
+        if (nome != null && !nome.isEmpty()) requestBuilder = requestBuilder.param("nome", nome);
+        if (estado != null && !estado.isEmpty()) requestBuilder = requestBuilder.param("estado", estado);
+        if (ativo != null) requestBuilder = requestBuilder.param("ativo", ativo.toString());
+
+        mockMvc.perform(requestBuilder)
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content.length()").value(clubesRetornados.getContent().size()))
+                .andExpect(jsonPath("$.content[0].nome").value("clube de time"))
+                .andExpect(jsonPath("$.content[1].siglaEstado").value("am"))
+                .andDo(MockMvcResultHandlers.print());
+
+        Mockito.verify(buscarClubeService, Mockito.times(1)).listarClubesFiltrados(
+                any(), any(), any(), any(Pageable.class)
+        );
+    }
+
+    @Test
+    void deveBuscarClubePorIdComSucesso() throws Exception {
+        Long id = 1L;
+        Clube clube = new Clube("clube de time","AM",true,LocalDate.of(2025,11,3));
+        clube.setId(id);
+        ClubeResponseDTO clubeDTO = ClubeResponseMapper.toClubeResponseDTO(clube);
+
+        Mockito.when(buscarClubeService.buscarClubePorId(id)).thenReturn(clube);
+
+        mockMvc.perform(get(PATH_COM_ID,id)
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is(HttpStatus.OK.value()))
+                .andExpect(jsonPath("$.nome").value(clubeDTO.getNome()))
+                .andExpect(jsonPath("$.siglaEstado").value(clubeDTO.getSiglaEstado()))
+                .andExpect(jsonPath("$.dataCriacao[0]").value(2025))
+                .andExpect(jsonPath("$.dataCriacao[1]").value(11))
+                .andExpect(jsonPath("$.dataCriacao[2]").value(3))
+                .andDo(MockMvcResultHandlers.print());
+
+        Mockito.verify(buscarClubeService, Mockito.times(1)).buscarClubePorId(id);
+    }
+
+    @Test
+    void deveRetornarNotFoundQuandoClubeNaoExistir() throws Exception {
+        Long id = 999L;
+        Mockito.when(buscarClubeService.buscarClubePorId(id))
+                .thenThrow(new ClubeNaoEncontradoException(id));
+
+        mockMvc.perform(get(PATH_COM_ID,id)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().is(HttpStatus.NOT_FOUND.value()))
+            .andDo(MockMvcResultHandlers.print());
+
+        Mockito.verify(buscarClubeService, Mockito.times(1)).buscarClubePorId(id);
+    }
+
+
+}

--- a/src/test/java/br/com/meli/teamcubation_partidas_de_futebol/util/PrintUtil.java
+++ b/src/test/java/br/com/meli/teamcubation_partidas_de_futebol/util/PrintUtil.java
@@ -1,0 +1,15 @@
+package br.com.meli.teamcubation_partidas_de_futebol.util;
+
+public final class PrintUtil {
+
+    private PrintUtil() {
+    }
+
+    public static void printInicioDoTeste(String nomeDoTeste) {
+        System.out.println("==> Iniciando teste: " + nomeDoTeste);
+    }
+
+    public static void printMensagemDeErro(String mensagem) {
+        System.out.println("Erro lançado: " + mensagem);
+    }
+}


### PR DESCRIPTION
### Adiciona testes para busca de clubes na controller

#### O que foi feito

- **BuscarClubeApiControllerTest**
  - Implementado teste de busca paginada de clubes com filtros opcionais (`nome`, `estado`, `ativo`) via método `deveBuscarTodosClubesComSucesso`.
  - Criado teste para busca de clube por id com sucesso pelo método `deveBuscarClubePorIdComSucesso`.
  - Adicionado teste para cenário de exceção (clube não encontrado) no método `deveRetornarNotFoundQuandoClubeNaoExistir`.
  - Configurado MockMvc com ControllerAdvice global e específico, além de resolução de argumentos Pageable.
  - Utilizado `PrintUtil` para exibir o início de cada teste.

#### Resumo
Testes abrangem busca de clubes com paginação, busca por id e tratamento de exceção na controller, garantindo a correta resposta e tratamento dos principais cenários.