### PR TITLE
docs(swagger): adiciona documentação completa da API para clubes, estádios, partidas, ranking e retrospecto

### DIFF
--- a/partidas-de-futebol-api/pom.xml
+++ b/partidas-de-futebol-api/pom.xml
@@ -37,13 +37,6 @@
             <artifactId>h2</artifactId>
             <scope>runtime</scope>
         </dependency>
-
-        <!-- Swagger -->
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.5</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/AtualizarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/AtualizarClubeApiController.java
@@ -5,11 +5,20 @@ import br.com.meli.teamcubation_partidas_de_futebol.clube.dto.ClubeResponseDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.clube.dto.mapper.ClubeResponseMapper;
 import br.com.meli.teamcubation_partidas_de_futebol.clube.model.Clube;
 import br.com.meli.teamcubation_partidas_de_futebol.clube.service.AtualizarClubeService;
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Clubes")
 @RestController
 @RequestMapping("/api/clube/atualizar")
 public class AtualizarClubeApiController {
@@ -19,9 +28,126 @@ public class AtualizarClubeApiController {
         this.atualizarClubeService = atualizarClubeService;
     }
 
+
+    @Operation(
+            summary = "Atualiza os dados de um clube",
+            description = "Atualiza nome, sigla do estado e data de criação do clube. Retorna 200 em caso de sucesso ou erro específico em cada cenário de exceção."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Clube atualizado com sucesso",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ClubeResponseDTO.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                  "nome":"Clube Atualizado",
+                  "siglaEstado":"AM",
+                  "dataCriacao":"2025-05-13"
+                }
+                """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Campos inválidos ou estado inexistente",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "campos-invalidos",
+                                    summary = "Request com campos inválidos",
+                                    value = """
+                    {
+                        "codigoErro": "CAMPO_INVALIDO",
+                        "dataHora": "04/08/2025 11:02:56",
+                        "mensagem": "Invalid request content.",
+                        "errors": {
+                            "siglaEstado": "A sigla do estado só pode ter 2 letras.",
+                            "nome": "O nome tem que ter no minimo duas letras;",
+                            "dataCriacao": "A data de criação não pode ser futura"
+                        }
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "estado-inexistente",
+                                    summary = "Tentativa de atualizar clube com estado que não existe",
+                                    value = """
+                    {
+                        "codigoErro": "ESTADO_INEXISTENTE",
+                        "dataHora": "04/08/2025 11:03:40",
+                        "mensagem": "Não é possivel criar o clube pois o estado AX não existe.",
+                        "errors": null
+                    }
+                    """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "409",
+            description = "Conflito de dados (data inválida ou duplicidade de clube)",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "data-criacao-posterior",
+                                    summary = "Data de criação após uma partida cadastrada",
+                                    value = """
+                    {
+                        "codigoErro": "DATA_CRIACAO_POSTERIOR_A_DATA_PARTIDA",
+                        "dataHora": "04/08/2025 11:52:08",
+                        "mensagem": "A data de criação do clube com id 1 está posterior a data de uma partida cadastrada.",
+                        "errors": null
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "clube-duplicado",
+                                    summary = "Nome duplicado para o mesmo estado",
+                                    value = """
+                    {
+                        "codigoErro": "CLUBE_DUPLICADO",
+                        "dataHora": "04/08/2025 11:04:33",
+                        "mensagem": "Já existe clube com este nome no mesmo estado.",
+                        "errors": null
+                    }
+                    """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Clube não encontrado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            name = "clube-nao-encontrado",
+                            summary = "Clube não existe na base de dados",
+                            value = """
+                {
+                    "codigoErro": "CLUBE_NAO_ENCONTRADO",
+                    "dataHora": "04/08/2025 11:52:23",
+                    "mensagem": "Clube com id 999 não encontrado.",
+                    "errors": null
+                }
+                """
+                    )
+            )
+    )
     @PutMapping("/{id}")
-    public ResponseEntity<ClubeResponseDTO> atualizar(@PathVariable Long id,
-                                                      @RequestBody @Valid AtualizarClubeRequestDTO clubeAtualizado) {
+    public ResponseEntity<ClubeResponseDTO> atualizar(
+            @RequestBody @Valid AtualizarClubeRequestDTO clubeAtualizado,
+            @Parameter(description = "ID do clube. Deve ser um número inteiro ou long.", example = "1")
+            @PathVariable Long id) {
+
         Clube clubeAlterado = atualizarClubeService.atualizar(clubeAtualizado, id);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ClubeResponseMapper.toClubeResponseDTO(clubeAlterado));

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/AtualizarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/AtualizarClubeApiController.java
@@ -15,12 +15,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Clubes")
 @RestController
-@RequestMapping("/api/clube/atualizar")
+@RequestMapping(value = "/api/clube/atualizar", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 public class AtualizarClubeApiController {
     private final AtualizarClubeService atualizarClubeService;
 
@@ -37,7 +38,6 @@ public class AtualizarClubeApiController {
             responseCode = "200",
             description = "Clube atualizado com sucesso",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ClubeResponseDTO.class),
                     examples = @ExampleObject(
                             value = """
@@ -54,7 +54,6 @@ public class AtualizarClubeApiController {
             responseCode = "400",
             description = "Campos inválidos ou estado inexistente",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = {
                             @ExampleObject(
@@ -92,7 +91,6 @@ public class AtualizarClubeApiController {
             responseCode = "409",
             description = "Conflito de dados (data inválida ou duplicidade de clube)",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = {
                             @ExampleObject(
@@ -126,7 +124,6 @@ public class AtualizarClubeApiController {
             responseCode = "404",
             description = "Clube não encontrado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             name = "clube-nao-encontrado",

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/BuscarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/BuscarClubeApiController.java
@@ -20,7 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "Clubes", description = "Endpoints para consulta e busca de clubes")
+@Tag(name = "Clubes", description = "Endpoints para busca, criação, atualização e inativação de clubes")
 @RestController
 @RequestMapping("/api/clube/buscar")
 public class BuscarClubeApiController {

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/BuscarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/BuscarClubeApiController.java
@@ -109,7 +109,10 @@ public class BuscarClubeApiController {
     )
     @GetMapping
     public Page<ClubeResponseDTO> listarClubes
-            (@RequestParam(required = false) String nome,
+
+            (
+            @Parameter(description = "Nome (opcional) para filtro", example = "testando")
+            @RequestParam(required = false) String nome,
              @RequestParam(required = false) String estado,
              @RequestParam(required = false) Boolean ativo,
              @Parameter(

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/BuscarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/BuscarClubeApiController.java
@@ -4,12 +4,23 @@ import br.com.meli.teamcubation_partidas_de_futebol.clube.dto.ClubeResponseDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.clube.dto.mapper.ClubeResponseMapper;
 import br.com.meli.teamcubation_partidas_de_futebol.clube.model.Clube;
 import br.com.meli.teamcubation_partidas_de_futebol.clube.service.BuscarClubeService;
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Clubes", description = "Endpoints para consulta e busca de clubes")
 @RestController
 @RequestMapping("/api/clube/buscar")
 public class BuscarClubeApiController {
@@ -19,16 +30,136 @@ public class BuscarClubeApiController {
         this.buscarClubeService = buscarClubeService;
     }
 
+    @Operation(
+            summary = "Lista clubes filtrando por nome, estado ou ativo",
+            description = "Retorna uma página de clubes, permitindo filtro opcional por nome, estado e situação de ativo. Suporta paginação."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Lista paginada de clubes",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ClubeResponseDTO.class),
+                    examples = {@ExampleObject(
+                            name = "lista com resultados",
+                            summary = "Retorno de clubes encontrados",
+                            value = """
+                            {
+                        "content": [
+                                 {
+                                     "nome": "clube de time atualizado",
+                                     "siglaEstado": "AM",
+                                     "dataCriacao": "2025-05-13"
+                                 },
+                                 {
+                                     "nome": "clube de time",
+                                     "siglaEstado": "AP",
+                                     "dataCriacao": "2025-05-13"
+                                 }
+                             ],
+                             "pageable": {
+                                 "pageNumber": 0,
+                                 "pageSize": 20,
+                                 "sort": {
+                                     "empty": true,
+                                     "sorted": false,
+                                     "unsorted": true
+                                 },
+                                 "offset": 0,
+                                 "paged": true,
+                                 "unpaged": false
+                             },
+                             "last": true,
+                             "totalElements": 2,
+                             "totalPages": 1,
+                             "first": true,
+                             "size": 20,
+                             "number": 0,
+                             "sort": {
+                                 "empty": true,
+                                 "sorted": false,
+                                 "unsorted": true
+                             },
+                             "numberOfElements": 2,
+                             "empty": false
+                         }
+                        """
+
+                    ),
+                    @ExampleObject(
+                            name = "casoSemResultados",
+                            summary = "Retorno quando não encontra clubes para o filtro ou se não há clubes cadastrados.",
+                            value = """
+                            {
+                              "content": [],
+                              "pageable": { "pageNumber": 0, "pageSize": 20, ... },
+                              "last": true,
+                              "totalElements": 0,
+                              "totalPages": 0,
+                              "first": true,
+                              "size": 20,
+                              "number": 0,
+                              "sort": { "empty": true, "sorted": false, "unsorted": true },
+                              "numberOfElements": 0,
+                              "empty": true
+                            }
+                            """
+                    )}
+            )
+    )
     @GetMapping
     public Page<ClubeResponseDTO> listarClubes
             (@RequestParam(required = false) String nome,
              @RequestParam(required = false) String estado,
              @RequestParam(required = false) Boolean ativo,
-             Pageable pageable){
+             @Parameter(
+                     description = "Campo para ordenação, por padrão já está nome, asc",
+                     example = "[\"\"]"
+             )
+             @PageableDefault(sort = "nome", direction = Sort.Direction.ASC) Pageable pageable){
         return buscarClubeService.listarClubesFiltrados(nome,estado,ativo,pageable);
     }
 
 
+    @Operation(
+            summary = "Busca um clube por ID",
+            description = "Retorna os detalhes de um clube localizado pelo seu identificador único."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Clube encontrado com sucesso",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ClubeResponseDTO.class),
+                    examples = @ExampleObject(
+                            value = """
+            {
+              "nome": "clube de time atualizado",
+              "siglaEstado": "AM",
+              "dataCriacao": "2025-05-13"
+            }
+            """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Clube não encontrado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            value = """
+            {
+              "codigoErro": "CLUBE_NAO_ENCONTRADO",
+              "dataHora": "04/08/2025 10:23:55",
+              "mensagem": "Clube com id 999 não encontrado.",
+              "errors": null
+            }
+            """
+                    )
+            )
+    )
     @GetMapping("/{id}")
     public ResponseEntity<ClubeResponseDTO> buscarPorId(@PathVariable Long id) {
         Clube clubeRetornado = buscarClubeService.buscarClubePorId(id);

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/BuscarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/BuscarClubeApiController.java
@@ -17,12 +17,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Clubes", description = "Endpoints para busca, criação, atualização e inativação de clubes")
 @RestController
-@RequestMapping("/api/clube/buscar")
+@RequestMapping(value = "/api/clube/buscar", produces = MediaType.APPLICATION_JSON_VALUE)
 public class BuscarClubeApiController {
     private final BuscarClubeService buscarClubeService;
 
@@ -38,7 +39,6 @@ public class BuscarClubeApiController {
             responseCode = "200",
             description = "Lista paginada de clubes",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ClubeResponseDTO.class),
                     examples = {@ExampleObject(
                             name = "lista com resultados",
@@ -132,7 +132,6 @@ public class BuscarClubeApiController {
             responseCode = "200",
             description = "Clube encontrado com sucesso",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ClubeResponseDTO.class),
                     examples = @ExampleObject(
                             value = """
@@ -149,7 +148,6 @@ public class BuscarClubeApiController {
             responseCode = "404",
             description = "Clube não encontrado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             value = """
@@ -163,7 +161,7 @@ public class BuscarClubeApiController {
                     )
             )
     )
-    @GetMapping("/{id}")
+    @GetMapping(value = "/{id}")
     public ResponseEntity<ClubeResponseDTO> buscarPorId(@PathVariable Long id) {
         Clube clubeRetornado = buscarClubeService.buscarClubePorId(id);
         return ResponseEntity.status(HttpStatus.OK)

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/CriarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/CriarClubeApiController.java
@@ -3,6 +3,13 @@ package br.com.meli.teamcubation_partidas_de_futebol.clube.controller;
 import br.com.meli.teamcubation_partidas_de_futebol.clube.dto.ClubeResponseDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.clube.dto.CriarClubeRequestDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.clube.service.CriarClubeService;
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Clubes")
 @RestController
 @RequestMapping("/api/clube/criar")
 public class CriarClubeApiController {
@@ -20,6 +28,84 @@ public class CriarClubeApiController {
         this.criarClubeService = criarClubeService;
     }
 
+
+    @Operation(
+            summary = "Cria um novo clube",
+            description = "Cadastra um novo clube. Retorna 201 ao sucesso."
+    )
+    @ApiResponse(
+            responseCode = "201",
+            description = "Clube criado com sucesso",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ClubeResponseDTO.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                  "nome":"Clube de Exemplo dezoito",
+                  "siglaEstado":"AM",
+                  "dataCriacao":"2025-05-13"
+                }
+                """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Campos inválidos ou estado inexistente",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "campos-invalidos",
+                                    summary = "Request com campos inválidos",
+                                    value = """
+                {
+                    "codigoErro": "CAMPO_INVALIDO",
+                    "dataHora": "04/08/2025 11:02:56",
+                    "mensagem": "Invalid request content.",
+                    "errors": {
+                        "siglaEstado": "A sigla do estado só pode ter 2 letras.",
+                        "nome": "O nome tem que ter no minimo duas letras;",
+                        "dataCriacao": "A data de criação não pode ser futura"
+                    }
+                }
+                """
+                            ),
+                            @ExampleObject(
+                                    name = "estado-inexistente",
+                                    summary = "Tentativa de criar clube com estado inexistente",
+                                    value = """
+                {
+                    "codigoErro": "ESTADO_INEXISTENTE",
+                    "dataHora": "04/08/2025 11:03:40",
+                    "mensagem": "Não é possivel criar o clube pois o estado AX não existe.",
+                    "errors": null
+                }
+                """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "409",
+            description = "Já existe clube com esse nome no estado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "codigoErro": "CLUBE_DUPLICADO",
+                    "dataHora": "04/08/2025 11:04:33",
+                    "mensagem": "Já existe clube com este nome no mesmo estado.",
+                    "errors": null
+                }
+                """
+                    )
+            )
+    )
     @PostMapping
     public ResponseEntity<ClubeResponseDTO> criar(@RequestBody @Valid CriarClubeRequestDTO clubeDTO) {
         return ResponseEntity.status(HttpStatus.CREATED)

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/CriarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/CriarClubeApiController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +21,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Clubes")
 @RestController
-@RequestMapping("/api/clube/criar")
+@RequestMapping(value = "/api/clube/criar",
+        consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 public class CriarClubeApiController {
     private final CriarClubeService criarClubeService;
 
@@ -37,7 +39,6 @@ public class CriarClubeApiController {
             responseCode = "201",
             description = "Clube criado com sucesso",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ClubeResponseDTO.class),
                     examples = @ExampleObject(
                             value = """
@@ -54,7 +55,6 @@ public class CriarClubeApiController {
             responseCode = "400",
             description = "Campos inválidos ou estado inexistente",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = {
                             @ExampleObject(
@@ -92,7 +92,6 @@ public class CriarClubeApiController {
             responseCode = "409",
             description = "Já existe clube com esse nome no estado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             value = """

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/InativarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/InativarClubeApiController.java
@@ -1,6 +1,14 @@
 package br.com.meli.teamcubation_partidas_de_futebol.clube.controller;
 
 import br.com.meli.teamcubation_partidas_de_futebol.clube.service.InativarClubeService;
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -8,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Clubes")
 @RestController
 @RequestMapping("/api/clube/inativar")
 public class InativarClubeApiController {
@@ -17,8 +26,38 @@ public class InativarClubeApiController {
         this.inativarClubeService = inativarClubeService;
     }
 
+    @Operation(
+            summary = "Inativa um clube por ID (soft delete)",
+            description = "Desativa um clube existente (ativo = false). Retorna 204 caso sucesso. Retorna 404 se não encontrar o clube."
+    )
+    @ApiResponse(
+            responseCode = "204 No Content",
+            description = "Clube inativado com sucesso"
+    )
+    @ApiResponse(
+            responseCode = "404 Not Found",
+            description = "Clube não encontrado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            name = "clube-nao-encontrado",
+                            summary = "Tentativa de inativar clube inexistente",
+                            value = """
+                {
+                    "codigoErro": "CLUBE_NAO_ENCONTRADO",
+                    "dataHora": "04/08/2025 12:00:00",
+                    "mensagem": "Clube com id 999 não encontrado.",
+                    "errors": null
+                }
+                """
+                    )
+            )
+    )
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletar(@PathVariable Long id) {
+    public ResponseEntity<Void> deletar(
+            @Parameter(description = "ID do clube a ser inativado", example = "1")
+            @PathVariable Long id) {
         inativarClubeService.inativarClubePorId(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/InativarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/InativarClubeApiController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Clubes")
 @RestController
-@RequestMapping("/api/clube/inativar")
+@RequestMapping(value = "/api/clube/inativar", produces = MediaType.APPLICATION_JSON_VALUE)
 public class InativarClubeApiController {
     private final InativarClubeService inativarClubeService;
 
@@ -38,7 +39,6 @@ public class InativarClubeApiController {
             responseCode = "404 Not Found",
             description = "Clube não encontrado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             name = "clube-nao-encontrado",
@@ -54,7 +54,7 @@ public class InativarClubeApiController {
                     )
             )
     )
-    @DeleteMapping("/{id}")
+    @DeleteMapping(value = "/{id}")
     public ResponseEntity<Void> deletar(
             @Parameter(description = "ID do clube a ser inativado", example = "1")
             @PathVariable Long id) {

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/dto/AtualizarClubeRequestDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/dto/AtualizarClubeRequestDTO.java
@@ -1,20 +1,46 @@
 package br.com.meli.teamcubation_partidas_de_futebol.clube.dto;
 
-import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 
+@Schema(description = "DTO para atualização dos dados de um clube")
 public class AtualizarClubeRequestDTO {
-    @NotBlank(message = "O nome não pode estar vazio.")
+    @Schema(
+            description = "Nome do clube. Mínimo 2 letras, apenas letras e espaços.",
+            example = "Clube Atualizado"
+    )
     @Size(min = 2, message = "O nome tem que ter no minimo duas letras;")
     @Pattern(regexp = "^[A-Za-zÀ-ÿ ]+$", message = "O nome deve conter apenas letras e espaços")
     private String nome;
-    @NotBlank(message = "A sigla do estado não pode estar vazia.")
+
+    @Schema(
+            description = "Sigla do estado, obrigatório 2 caracteres.",
+            example = "AM",
+            minLength = 2,
+            maxLength = 2
+    )
     @Size(min = 2, max = 2, message = "A sigla do estado só pode ter 2 letras.")
     private String siglaEstado;
+
+    @Schema(
+            description = "Data de criação do clube. Não pode ser futura.",
+            example = "2025-05-13",
+            type = "string",
+            format = "date"
+    )
     @NotNull(message = "Data de criação obrigatória")
     @PastOrPresent(message = "A data de criação não pode ser futura")
     private LocalDate dataCriacao;
+
+    @Schema(
+            description = "Se o clube está ativo ou não",
+            example = "true"
+    )
     private Boolean ativo;
 
     public AtualizarClubeRequestDTO() {

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/dto/ClubeResponseDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/dto/ClubeResponseDTO.java
@@ -1,10 +1,17 @@
 package br.com.meli.teamcubation_partidas_de_futebol.clube.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.time.LocalDate;
 
 public class ClubeResponseDTO {
+    @Schema(description = "Nome oficial do clube", example = "Flamengo")
     private String nome;
+
+    @Schema(description = "Sigla do estado do clube", example = "RJ")
     private String siglaEstado;
+
+    @Schema(description = "Data de criação do clube", example = "2025-05-13", type = "string", format = "date")
     private LocalDate dataCriacao;
 
     public ClubeResponseDTO() {

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/dto/CriarClubeRequestDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/dto/CriarClubeRequestDTO.java
@@ -1,17 +1,39 @@
 package br.com.meli.teamcubation_partidas_de_futebol.clube.dto;
 
-import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 import java.time.LocalDate;
 
+@Schema(description = "DTO para criar um novo clube")
 public class CriarClubeRequestDTO {
-    @NotBlank(message = "O nome não pode estar vazio.")
+    @Schema(
+            description = "Nome do clube. Mínimo 2 letras, apenas letras e espaços.",
+            example = "Clube de Exemplo dezoito"
+    )
     @Size(min = 2, message = "O nome tem que ter no minimo duas letras;")
     @Pattern(regexp = "^[A-Za-zÀ-ÿ ]+$", message = "O nome deve conter apenas letras e espaços")
     private String nome;
-    @NotBlank(message = "A sigla do estado não pode estar vazia.")
+
+    @Schema(
+            description = "Sigla do estado, obrigatório 2 caracteres.",
+            example = "AM",
+            minLength = 2,
+            maxLength = 2
+    )
     @Size(min = 2, max = 2, message = "A sigla do estado só pode ter 2 letras.")
     private String siglaEstado;
+
+
+    @Schema(
+            description = "Data de criação do clube. Não pode ser futura.",
+            example = "2025-05-13",
+            type = "string",
+            format = "date"
+    )
     @NotNull(message = "Data de criação obrigatória")
     @PastOrPresent(message = "A data de criação não pode ser futura")
     private LocalDate dataCriacao;

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/config/SwaggerConfig.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/config/SwaggerConfig.java
@@ -1,0 +1,27 @@
+package br.com.meli.teamcubation_partidas_de_futebol.config;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("API Partidas de Futebol")
+                        .version("v1.0.0")
+                        .description("Documentação da API de partidas de futebol")
+                        .contact(new Contact().name("Yuri Capella").email("email@email.com"))
+                        .license(new License().name("Apache 2.0").url("https://www.apache.org/licenses/LICENSE-2.0.html"))
+                )
+                .externalDocs(new ExternalDocumentation()
+                        .description("Veja mais sobre o projeto")
+                        .url("https://github.com/yuricapella/teamcubation-partidas-de-futebol"));
+    }
+}

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/AtualizarEstadioApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/AtualizarEstadioApiController.java
@@ -3,11 +3,21 @@ package br.com.meli.teamcubation_partidas_de_futebol.estadio.controller;
 import br.com.meli.teamcubation_partidas_de_futebol.estadio.dto.AtualizarEstadioRequestDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.estadio.dto.EstadioEnderecoResponseDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.estadio.service.AtualizarEstadioService;
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+
+@Tag(name = "Estádios")
 @RestController
 @RequestMapping("/api/estadio/atualizar")
 public class AtualizarEstadioApiController {
@@ -17,9 +27,130 @@ public class AtualizarEstadioApiController {
         this.atualizarEstadioService = atualizarEstadioService;
     }
 
+    @Operation(
+            summary = "Atualiza os dados de um estádio",
+            description = "Edita nome e/ou endereço de estádio. Retorna 200 em caso de sucesso. Retorna 400 para dados inválidos, 409 para nome já existente e 404 para estádio não encontrado."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Estádio atualizado com sucesso",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = EstadioEnderecoResponseDTO.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "nome": "Estadio de time atualizado com cep meli",
+                    "endereco": {
+                        "cep": "88032-005",
+                        "logradouro": "Rodovia José Carlos Daux",
+                        "bairro": "Saco Grande",
+                        "localidade": "Florianópolis",
+                        "uf": "SC",
+                        "estado": "Santa Catarina"
+                    }
+                }
+                """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Campos inválidos",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "nomeInvalidoECepNulo",
+                                    summary = "Nome com menos de 3 letras, CEP nulo",
+                                    value = """
+                    {
+                        "codigoErro": "CAMPO_INVALIDO",
+                        "dataHora": "04/08/2025 16:17:13",
+                        "mensagem": "Invalid request content.",
+                        "errors": {
+                            "nome": "O nome tem que ter no minimo três letras",
+                            "cep": "não deve ser nulo"
+                        }
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "nomeInvalidoECepInvalido",
+                                    summary = "Nome com menos de 3 letras, CEP formato inválido",
+                                    value = """
+                    {
+                        "codigoErro": "CAMPO_INVALIDO",
+                        "dataHora": "04/08/2025 16:18:31",
+                        "mensagem": "Invalid request content.",
+                        "errors": {
+                            "nome": "O nome tem que ter no minimo três letras",
+                            "cep": "O cep deve conter exatamente 8 dígitos numéricos"
+                        }
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "nomeNuloECepInvalido",
+                                    summary = "Nome nulo, CEP formato inválido",
+                                    value = """
+                    {
+                        "codigoErro": "CAMPO_INVALIDO",
+                        "dataHora": "04/08/2025 16:18:54",
+                        "mensagem": "Invalid request content.",
+                        "errors": {
+                            "nome": "não deve ser nulo",
+                            "cep": "O cep deve conter exatamente 8 dígitos numéricos"
+                        }
+                    }
+                    """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "409",
+            description = "Estádio com nome duplicado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "codigoErro": "ESTADIO_JA_EXISTE",
+                    "dataHora": "04/08/2025 16:15:10",
+                    "mensagem": "Já existe um estadio com este nome.",
+                    "errors": null
+                }
+                """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Estádio não encontrado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "codigoErro": "ESTADIO_NAO_ENCONTRADO",
+                    "dataHora": "04/08/2025 16:14:43",
+                    "mensagem": "Estadio com id 999 não encontrado.",
+                    "errors": null
+                }
+                """
+                    )
+            )
+    )
     @PutMapping("/{id}")
     public ResponseEntity<EstadioEnderecoResponseDTO> atualizar
-            (@RequestBody @Valid AtualizarEstadioRequestDTO atualizarEstadioRequestDTO, @PathVariable Long id) {
+            (@RequestBody @Valid AtualizarEstadioRequestDTO atualizarEstadioRequestDTO,
+             @Parameter(description = "ID do estádio a ser atualizado", example = "1")
+             @PathVariable Long id) {
+
         EstadioEnderecoResponseDTO estadioAtualizado = atualizarEstadioService.atualizarEstadio(atualizarEstadioRequestDTO, id);
         return ResponseEntity.status(HttpStatus.OK).body(estadioAtualizado);
     }

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/AtualizarEstadioApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/AtualizarEstadioApiController.java
@@ -13,13 +13,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 
 @Tag(name = "Estádios")
 @RestController
-@RequestMapping("/api/estadio/atualizar")
+@RequestMapping(value = "/api/estadio/atualizar", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 public class AtualizarEstadioApiController {
     private final AtualizarEstadioService atualizarEstadioService;
 
@@ -35,7 +36,6 @@ public class AtualizarEstadioApiController {
             responseCode = "200",
             description = "Estádio atualizado com sucesso",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = EstadioEnderecoResponseDTO.class),
                     examples = @ExampleObject(
                             value = """
@@ -58,7 +58,6 @@ public class AtualizarEstadioApiController {
             responseCode = "400",
             description = "Campos inválidos",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = {
                             @ExampleObject(
@@ -113,7 +112,6 @@ public class AtualizarEstadioApiController {
             responseCode = "409",
             description = "Estádio com nome duplicado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             value = """
@@ -131,7 +129,6 @@ public class AtualizarEstadioApiController {
             responseCode = "404",
             description = "Estádio não encontrado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             value = """
@@ -145,7 +142,7 @@ public class AtualizarEstadioApiController {
                     )
             )
     )
-    @PutMapping("/{id}")
+    @PutMapping(value = "/{id}")
     public ResponseEntity<EstadioEnderecoResponseDTO> atualizar
             (@RequestBody @Valid AtualizarEstadioRequestDTO atualizarEstadioRequestDTO,
              @Parameter(description = "ID do estádio a ser atualizado", example = "1")

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/BuscarEstadioApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/BuscarEstadioApiController.java
@@ -3,12 +3,23 @@ package br.com.meli.teamcubation_partidas_de_futebol.estadio.controller;
 import br.com.meli.teamcubation_partidas_de_futebol.estadio.dto.EstadioEnderecoResponseDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.estadio.dto.EstadioResponseDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.estadio.service.BuscarEstadioService;
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Estádios")
 @RestController
 @RequestMapping("/api/estadio/buscar")
 public class BuscarEstadioApiController {
@@ -18,15 +29,138 @@ public class BuscarEstadioApiController {
         this.buscarEstadioService = buscarEstadioService;
     }
 
+    @Operation(
+            summary = "Busca estádio por id (com endereço via API externa)",
+            description = "Retorna os campos completos do estádio, incluindo endereço via integração com VIACEP. 404 se não existe."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Estádio encontrado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = EstadioEnderecoResponseDTO.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "nome": "Estadio de time atualizado com cep meli",
+                    "endereco": {
+                        "cep": "88032-005",
+                        "logradouro": "Rodovia José Carlos Daux",
+                        "bairro": "Saco Grande",
+                        "localidade": "Florianópolis",
+                        "uf": "SC",
+                        "estado": "Santa Catarina"
+                    }
+                }
+                """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Estádio não encontrado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "codigoErro": "ESTADIO_NAO_ENCONTRADO",
+                    "dataHora": "04/08/2025 16:32:26",
+                    "mensagem": "Estadio com id 999 não encontrado.",
+                    "errors": null
+                }
+                """
+                    )
+            )
+    )
     @GetMapping("/{id}")
-    public ResponseEntity<EstadioEnderecoResponseDTO> buscar(@PathVariable Long id) {
+    public ResponseEntity<EstadioEnderecoResponseDTO> buscar(
+            @Parameter(description = "ID do estádio a buscar", example = "1")
+            @PathVariable Long id) {
         EstadioEnderecoResponseDTO estadioBuscado = buscarEstadioService.buscarEstadioComEnderecoPorId(id);
         return ResponseEntity.status(HttpStatus.OK).body(estadioBuscado);
     }
 
+    @Operation(
+            summary = "Lista estádios com filtro por nome e paginação",
+            description = "Permite listar todos os estádios paginados e filtrar por nome. Retorna 200 com lista vazia se não houver resultados. Os resultados podem ser ordenados pelo campo nome (ascendente/descendente)."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Lista paginada de estádios",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = EstadioResponseDTO.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "comResultados",
+                                    summary = "Exemplo de lista com estádios encontrados",
+                                    value = """
+                    {
+                        "content": [
+                            { "nome": "Estadio de time atualizado com cep meli" },
+                            { "nome": "Estadio de time atualizado dois" },
+                            { "nome": "Estadio de time tres" }
+                        ],
+                        "pageable": {
+                            "pageNumber": 0,
+                            "pageSize": 20,
+                            "sort": { "empty": true, "sorted": false, "unsorted": true },
+                            "offset": 0,
+                            "paged": true,
+                            "unpaged": false
+                        },
+                        "last": true,
+                        "totalPages": 1,
+                        "totalElements": 11,
+                        "first": true,
+                        "size": 20,
+                        "number": 0,
+                        "sort": { "empty": true, "sorted": false, "unsorted": true },
+                        "numberOfElements": 11,
+                        "empty": false
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "vazio",
+                                    summary = "Exemplo de lista vazia (sem resultados para o filtro)",
+                                    value = """
+                    {
+                        "content": [],
+                        "pageable": {
+                            "pageNumber": 0,
+                            "pageSize": 20,
+                            "sort": { "empty": true, "sorted": false, "unsorted": true },
+                            "offset": 0,
+                            "paged": true,
+                            "unpaged": false
+                        },
+                        "last": true,
+                        "totalPages": 0,
+                        "totalElements": 0,
+                        "first": true,
+                        "size": 20,
+                        "number": 0,
+                        "sort": { "empty": true, "sorted": false, "unsorted": true },
+                        "numberOfElements": 0,
+                        "empty": true
+                    }
+                    """
+                            )
+                    }
+            )
+    )
     @GetMapping
     public Page<EstadioResponseDTO> buscarTodosEstadiosFiltrados(
-            @RequestParam(required = false) String nome, Pageable pageable) {
+            @Parameter(description = "Nome (opcional) para filtro", example = "Arena")
+            @RequestParam(required = false) String nome,
+            @Parameter(
+                    description = "Campo para ordenação, por padrão já está nome, asc",
+                    example = "[\"\"]"
+            )
+            @PageableDefault(sort = "nome", direction = Sort.Direction.ASC) Pageable pageable) {
         return buscarEstadioService.listarEstadiosFiltrados(nome,pageable);
     }
 }

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/BuscarEstadioApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/BuscarEstadioApiController.java
@@ -16,12 +16,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Estádios")
 @RestController
-@RequestMapping("/api/estadio/buscar")
+@RequestMapping(value = "/api/estadio/buscar", produces = MediaType.APPLICATION_JSON_VALUE)
 public class BuscarEstadioApiController {
     private final BuscarEstadioService buscarEstadioService;
 
@@ -37,7 +38,6 @@ public class BuscarEstadioApiController {
             responseCode = "200",
             description = "Estádio encontrado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = EstadioEnderecoResponseDTO.class),
                     examples = @ExampleObject(
                             value = """
@@ -60,7 +60,6 @@ public class BuscarEstadioApiController {
             responseCode = "404",
             description = "Estádio não encontrado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             value = """
@@ -74,7 +73,7 @@ public class BuscarEstadioApiController {
                     )
             )
     )
-    @GetMapping("/{id}")
+    @GetMapping(value = "/{id}")
     public ResponseEntity<EstadioEnderecoResponseDTO> buscar(
             @Parameter(description = "ID do estádio a buscar", example = "1")
             @PathVariable Long id) {
@@ -90,7 +89,6 @@ public class BuscarEstadioApiController {
             responseCode = "200",
             description = "Lista paginada de estádios",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = EstadioResponseDTO.class),
                     examples = {
                             @ExampleObject(

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/CriarEstadioApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/CriarEstadioApiController.java
@@ -2,8 +2,14 @@ package br.com.meli.teamcubation_partidas_de_futebol.estadio.controller;
 
 import br.com.meli.teamcubation_partidas_de_futebol.estadio.dto.CriarEstadioRequestDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.estadio.dto.EstadioEnderecoResponseDTO;
-import br.com.meli.teamcubation_partidas_de_futebol.estadio.dto.EstadioResponseDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.estadio.service.CriarEstadioService;
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Estádios")
 @RestController
 @RequestMapping("/api/estadio/criar")
 public class CriarEstadioApiController {
@@ -21,6 +28,106 @@ public class CriarEstadioApiController {
         this.criarEstadioService = criarEstadioService;
     }
 
+    @Operation(
+            summary = "Cria um novo estádio",
+            description = "Cadastra um novo estádio informando nome e cep. Retorna 201 com os dados completos e endereço resolvido por VIACEP."
+    )
+    @ApiResponse(
+            responseCode = "201",
+            description = "Estádio criado com sucesso",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = EstadioEnderecoResponseDTO.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "nome": "Arena Central",
+                    "endereco": {
+                        "cep": "88032-005",
+                        "logradouro": "Rodovia José Carlos Daux",
+                        "bairro": "Saco Grande",
+                        "localidade": "Florianópolis",
+                        "uf": "SC",
+                        "estado": "Santa Catarina"
+                    }
+                }
+                """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Campos inválidos",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "nomeInvalidoECepNulo",
+                                    summary = "Nome com menos de 3 letras, CEP nulo",
+                                    value = """
+                    {
+                        "codigoErro": "CAMPO_INVALIDO",
+                        "dataHora": "04/08/2025 16:17:13",
+                        "mensagem": "Invalid request content.",
+                        "errors": {
+                            "nome": "O nome tem que ter no minimo três letras",
+                            "cep": "não deve ser nulo"
+                        }
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "nomeInvalidoECepInvalido",
+                                    summary = "Nome com menos de 3 letras, CEP formato inválido",
+                                    value = """
+                    {
+                        "codigoErro": "CAMPO_INVALIDO",
+                        "dataHora": "04/08/2025 16:18:31",
+                        "mensagem": "Invalid request content.",
+                        "errors": {
+                            "nome": "O nome tem que ter no minimo três letras",
+                            "cep": "O cep deve conter exatamente 8 dígitos numéricos"
+                        }
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "nomeNuloECepInvalido",
+                                    summary = "Nome nulo, CEP formato inválido",
+                                    value = """
+                    {
+                        "codigoErro": "CAMPO_INVALIDO",
+                        "dataHora": "04/08/2025 16:18:54",
+                        "mensagem": "Invalid request content.",
+                        "errors": {
+                            "nome": "não deve ser nulo",
+                            "cep": "O cep deve conter exatamente 8 dígitos numéricos"
+                        }
+                    }
+                    """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "409",
+            description = "Estádio com nome duplicado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "codigoErro": "ESTADIO_JA_EXISTE",
+                    "dataHora": "04/08/2025 16:15:10",
+                    "mensagem": "Já existe um estadio com este nome.",
+                    "errors": null
+                }
+                """
+                    )
+            )
+    )
     @PostMapping
     public ResponseEntity<EstadioEnderecoResponseDTO> criar(@RequestBody @Valid CriarEstadioRequestDTO criarEstadioRequestDTO) {
         EstadioEnderecoResponseDTO estadioCriado = criarEstadioService.criarEstadio(criarEstadioRequestDTO);

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/CriarEstadioApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/CriarEstadioApiController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Estádios")
 @RestController
-@RequestMapping("/api/estadio/criar")
+@RequestMapping(value = "/api/estadio/criar", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 public class CriarEstadioApiController {
     private final CriarEstadioService criarEstadioService;
 
@@ -36,7 +37,6 @@ public class CriarEstadioApiController {
             responseCode = "201",
             description = "Estádio criado com sucesso",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = EstadioEnderecoResponseDTO.class),
                     examples = @ExampleObject(
                             value = """
@@ -59,7 +59,6 @@ public class CriarEstadioApiController {
             responseCode = "400",
             description = "Campos inválidos",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = {
                             @ExampleObject(
@@ -114,7 +113,6 @@ public class CriarEstadioApiController {
             responseCode = "409",
             description = "Estádio com nome duplicado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             value = """

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/dto/AtualizarEstadioRequestDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/dto/AtualizarEstadioRequestDTO.java
@@ -1,14 +1,26 @@
 package br.com.meli.teamcubation_partidas_de_futebol.estadio.dto;
 
-import jakarta.validation.constraints.NotBlank;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "DTO para atualização dos dados de um estádio (nome e cep)")
 public class AtualizarEstadioRequestDTO {
-    @NotBlank(message = "O nome não pode estar vazio.")
+    @Schema(
+            description = "Nome do estádio. Mínimo 3 letras, apenas letras sem acento e espaços.",
+            example = "Estádio Municipal"
+    )
+    @NotNull
     @Size(min = 3, message = "O nome tem que ter no minimo três letras")
     @Pattern(regexp = "^[A-Za-z ]+$", message = "O nome deve conter apenas letras sem acento e espaços")
     private String nome;
+
+    @Schema(
+            description = "CEP do estádio. Exatamente 8 dígitos numéricos.",
+            example = "88032005"
+    )
+    @NotNull
     @Pattern(regexp = "^\\d{8}$", message = "O cep deve conter exatamente 8 dígitos numéricos")
     private String cep;
 

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/dto/CepResponseDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/dto/CepResponseDTO.java
@@ -1,11 +1,20 @@
 package br.com.meli.teamcubation_partidas_de_futebol.estadio.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "DTO com informações detalhadas do endereço provenientes do CEP.")
 public class CepResponseDTO {
+    @Schema(description = "CEP consultado", example = "88032005")
     private String cep;
+    @Schema(description = "Logradouro do endereço", example = "Rodovia José Carlos Daux")
     private String logradouro;
+    @Schema(description = "Bairro do endereço", example = "Saco Grande")
     private String bairro;
+    @Schema(description = "Cidade (localidade)", example = "Florianópolis")
     private String localidade;
+    @Schema(description = "UF do endereço", example = "SC")
     private String uf;
+    @Schema(description = "Nome do estado", example = "Santa Catarina")
     private String estado;
 
     public CepResponseDTO() {

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/dto/CriarEstadioRequestDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/dto/CriarEstadioRequestDTO.java
@@ -1,12 +1,26 @@
 package br.com.meli.teamcubation_partidas_de_futebol.estadio.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "DTO para criação de estádio (nome e cep)")
 public class CriarEstadioRequestDTO {
+    @Schema(
+            description = "Nome do estádio. Mínimo 3 letras, apenas letras sem acento e espaços.",
+            example = "Arena Central"
+    )
+    @NotNull
     @Size(min = 3, message = "O nome tem que ter no minimo três letras")
     @Pattern(regexp = "^[A-Za-z ]+$", message = "O nome deve conter apenas letras sem acento e espaços")
     private String nome;
+
+    @Schema(
+            description = "CEP do estádio. Exatamente 8 dígitos numéricos.",
+            example = "88032005"
+    )
+    @NotNull
     @Pattern(regexp = "^\\d{8}$", message = "O cep deve conter exatamente 8 dígitos numéricos")
     private String cep;
 

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/dto/EstadioEnderecoResponseDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/dto/EstadioEnderecoResponseDTO.java
@@ -1,6 +1,11 @@
 package br.com.meli.teamcubation_partidas_de_futebol.estadio.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "DTO de resposta contendo o nome do estádio e os dados completos do endereço baseado no cep.")
 public record EstadioEnderecoResponseDTO(
+        @Schema(description = "Nome do estádio", example = "Estadio de time atualizado com cep meli")
         String nome,
+        @Schema(description = "Dados detalhados do endereço do estádio")
         CepResponseDTO endereco
 ) {}

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/dto/EstadioResponseDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/dto/EstadioResponseDTO.java
@@ -1,6 +1,10 @@
 package br.com.meli.teamcubation_partidas_de_futebol.estadio.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "DTO de resposta simples com apenas o nome do estádio.")
 public class EstadioResponseDTO {
+    @Schema(description = "Nome do estádio", example = "Estádio do Pacaembu")
     private String nome;
 
     public EstadioResponseDTO() {

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/AtualizarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/AtualizarPartidaApiController.java
@@ -1,15 +1,24 @@
 package br.com.meli.teamcubation_partidas_de_futebol.partida.controller;
 
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.dto.AtualizarPartidaRequestDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.dto.PartidaResponseDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.dto.mapper.PartidaResponseMapper;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.model.Partida;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.service.AtualizarPartidaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Partidas")
 @RestController
 @RequestMapping("/api/partida/atualizar")
 public class AtualizarPartidaApiController {
@@ -19,8 +28,188 @@ public class AtualizarPartidaApiController {
         this.atualizarPartidaService = atualizarPartidaService;
     }
 
+    @Operation(
+            summary = "Atualiza os dados de uma partida",
+            description = "Edita partida existente, validando clubes, estádio, gols, datas. 200 OK se sucesso, 400 para campos ou entidades inválidas, 409 para regras de negócio e 404 para elementos não encontrados."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Partida atualizada com sucesso",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PartidaResponseDTO.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "clubeMandante": {
+                        "nome": "clube de time atualizado",
+                        "siglaEstado": "AM",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "clubeVisitante": {
+                        "nome": "clube de time",
+                        "siglaEstado": "AP",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "estadio": {
+                        "nome": "Estadio de time atualizado com cep meli"
+                    },
+                    "golsMandante": 2,
+                    "golsVisitante": 2,
+                    "dataHora": "10/06/2025 21:00:00",
+                    "resultado": "EMPATE"
+                }
+                """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Dados inválidos, clubes iguais, clubes/estádio inexistentes, gols negativos ou data futura",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "campos-invalidos",
+                                    summary = "Gols negativos e data futura",
+                                    value = """
+                    {
+                        "codigoErro": "CAMPO_INVALIDO",
+                        "dataHora": "04/08/2025 19:14:14",
+                        "mensagem": "Invalid request content.",
+                        "errors": {
+                            "golsMandante": "O número de gols do mandante não pode ser negativo",
+                            "golsVisitante": "O número de gols do visitante não pode ser negativo",
+                            "dataHora": "A data da partida não pode ser futura"
+                        }
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "clubes-iguais",
+                                    summary = "Clubes mandante e visitante iguais",
+                                    value = """
+                    {
+                        "codigoErro": "CLUBES_IGUAIS",
+                        "dataHora": "04/08/2025 19:14:29",
+                        "mensagem": "Não é possivel criar a partida pois os clubes são iguais.",
+                        "errors": null
+                    }
+                    """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "409",
+            description = "Conflitos de regras de negócio: datas, clube inativo, partidas próximas, estádio já ocupado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "data-antes-criacao-clube",
+                                    summary = "Data da partida anterior à criação de clube",
+                                    value = """
+                    {
+                        "codigoErro": "DATA_PARTIDA_ANTERIOR_A_CRIACAO_DO_CLUBE",
+                        "dataHora": "04/08/2025 19:14:42",
+                        "mensagem": "Não pode cadastrar uma partida para uma data anterior à data de criação do clube.",
+                        "errors": null
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "clube-inativo",
+                                    summary = "Clube envolvido está inativo",
+                                    value = """
+                    {
+                        "codigoErro": "CLUBE_INATIVO",
+                        "dataHora": "04/08/2025 19:15:02",
+                        "mensagem": "Não é possivel criar a partida pois há um clube inativo",
+                        "errors": null
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "partidas-menor-48h",
+                                    summary = "Clube com outras partidas em menos de 48h",
+                                    value = """
+                    {
+                        "codigoErro": "CLUBE_TEM_PARTIDAS_COM_DATA_MENOR_QUE_48_HORAS_DA_NOVA_PARTIDA",
+                        "dataHora": "04/08/2025 19:17:18",
+                        "mensagem": "Não é possível criar a partida pois um dos clubes já possui uma partida cadastrada em menos de 48 horas desta data.",
+                        "errors": null
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "estadio-ja-tem-partida-no-dia",
+                                    summary = "Estádio já possui partida marcada para o mesmo dia",
+                                    value = """
+                    {
+                        "codigoErro": "ESTADIO_JA_POSSUI_PARTIDA_MARCADA_NO_MESMO_DIA",
+                        "dataHora": "04/08/2025 19:25:18",
+                        "mensagem": "Não é possivel criar a partida pois no estádio já tem uma partida marcada para o mesmo dia",
+                        "errors": null
+                    }
+                    """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Clube, estádio ou partida não encontrada",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "clube-nao-encontrado",
+                                    summary = "Clube não encontrado",
+                                    value = """
+                {
+                    "codigoErro": "CLUBE_NAO_ENCONTRADO",
+                    "dataHora": "04/08/2025 19:27:34",
+                    "mensagem": "Clube com id 999 não encontrado.",
+                    "errors": null
+                }
+                """
+                            ),
+                            @ExampleObject(
+                                    name = "estadio-nao-encontrado",
+                                    summary = "Estádio não encontrado",
+                                    value = """
+                {
+                    "codigoErro": "ESTADIO_NAO_ENCONTRADO",
+                    "dataHora": "04/08/2025 19:28:03",
+                    "mensagem": "Estadio com id 999 não encontrado.",
+                    "errors": null
+                }
+                """
+                            ),
+                            @ExampleObject(
+                                    name = "partida-nao-encontrada",
+                                    summary = "Partida não encontrada",
+                                    value = """
+                {
+                    "codigoErro": "PARTIDA_NAO_ENCONTRADA",
+                    "dataHora": "04/08/2025 19:29:10",
+                    "mensagem": "Partida com id 999 não encontrada.",
+                    "errors": null
+                }
+                """
+                            )
+                    }
+            )
+    )
     @PutMapping("/{id}")
-    public ResponseEntity<PartidaResponseDTO> atualizarPartidaPorId(@RequestBody @Valid AtualizarPartidaRequestDTO atualizarPartidaRequestDTO, @PathVariable Long id) {
+    public ResponseEntity<PartidaResponseDTO> atualizarPartidaPorId(
+            @RequestBody @Valid AtualizarPartidaRequestDTO atualizarPartidaRequestDTO,
+            @Parameter(description = "ID da partida a ser atualizada", example = "1")
+            @PathVariable Long id) {
         Partida partidaAtualizada = atualizarPartidaService.atualizarPartida(atualizarPartidaRequestDTO, id);
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/AtualizarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/AtualizarPartidaApiController.java
@@ -15,12 +15,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Partidas")
 @RestController
-@RequestMapping("/api/partida/atualizar")
+@RequestMapping(value = "/api/partida/atualizar", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 public class AtualizarPartidaApiController {
     private final AtualizarPartidaService atualizarPartidaService;
 
@@ -36,7 +37,6 @@ public class AtualizarPartidaApiController {
             responseCode = "200",
             description = "Partida atualizada com sucesso",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = PartidaResponseDTO.class),
                     examples = @ExampleObject(
                             value = """
@@ -67,7 +67,6 @@ public class AtualizarPartidaApiController {
             responseCode = "400",
             description = "Dados inválidos, clubes iguais, clubes/estádio inexistentes, gols negativos ou data futura",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = {
                             @ExampleObject(
@@ -105,7 +104,6 @@ public class AtualizarPartidaApiController {
             responseCode = "409",
             description = "Conflitos de regras de negócio: datas, clube inativo, partidas próximas, estádio já ocupado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = {
                             @ExampleObject(
@@ -163,7 +161,6 @@ public class AtualizarPartidaApiController {
             responseCode = "404",
             description = "Clube, estádio ou partida não encontrada",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = {
                             @ExampleObject(
@@ -205,7 +202,7 @@ public class AtualizarPartidaApiController {
                     }
             )
     )
-    @PutMapping("/{id}")
+    @PutMapping(value = "/{id}")
     public ResponseEntity<PartidaResponseDTO> atualizarPartidaPorId(
             @RequestBody @Valid AtualizarPartidaRequestDTO atualizarPartidaRequestDTO,
             @Parameter(description = "ID da partida a ser atualizada", example = "1")

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/BuscarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/BuscarPartidaApiController.java
@@ -17,12 +17,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Partidas")
 @RestController
-@RequestMapping("/api/partida/buscar")
+@RequestMapping(value = "/api/partida/buscar", produces = MediaType.APPLICATION_JSON_VALUE)
 public class BuscarPartidaApiController {
     private final BuscarPartidaService buscarPartidaService;
 
@@ -38,7 +39,6 @@ public class BuscarPartidaApiController {
             responseCode = "200",
             description = "Partida encontrada com sucesso",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = PartidaResponseDTO.class),
                     examples = @ExampleObject(
                             value = """
@@ -69,7 +69,6 @@ public class BuscarPartidaApiController {
             responseCode = "404",
             description = "Partida não encontrada",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             value = """
@@ -83,7 +82,7 @@ public class BuscarPartidaApiController {
                     )
             )
     )
-    @GetMapping("/{id}")
+    @GetMapping(value = "/{id}")
     public ResponseEntity<PartidaResponseDTO> buscarPartidaPorId(@PathVariable Long id) {
         Partida partidaRetornada = buscarPartidaService.buscarPartidaPorId(id);
         return ResponseEntity
@@ -99,7 +98,6 @@ public class BuscarPartidaApiController {
             responseCode = "200",
             description = "Lista paginada de partidas",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = PartidaResponseDTO.class),
                     examples = {
                             @ExampleObject(

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/BuscarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/BuscarPartidaApiController.java
@@ -1,15 +1,26 @@
 package br.com.meli.teamcubation_partidas_de_futebol.partida.controller;
 
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.dto.PartidaResponseDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.dto.mapper.PartidaResponseMapper;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.model.Partida;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.service.BuscarPartidaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Partidas")
 @RestController
 @RequestMapping("/api/partida/buscar")
 public class BuscarPartidaApiController {
@@ -19,6 +30,59 @@ public class BuscarPartidaApiController {
         this.buscarPartidaService = buscarPartidaService;
     }
 
+    @Operation(
+            summary = "Busca partida por ID",
+            description = "Busca uma partida específica pelo ID. Retorna 200 se encontrada, 404 se não existe."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Partida encontrada com sucesso",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PartidaResponseDTO.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "clubeMandante": {
+                        "nome": "Clube Mandante",
+                        "siglaEstado": "AM",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "clubeVisitante": {
+                        "nome": "Clube Visitante",
+                        "siglaEstado": "AP",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "estadio": {
+                        "nome": "Estadio Exemplo"
+                    },
+                    "golsMandante": 2,
+                    "golsVisitante": 1,
+                    "dataHora": "10/06/2025 21:00:00",
+                    "resultado": "VITORIA_MANDANTE"
+                }
+                """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Partida não encontrada",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "codigoErro": "PARTIDA_NAO_ENCONTRADA",
+                    "dataHora": "04/08/2025 23:30:00",
+                    "mensagem": "Partida com id 999 não encontrada.",
+                    "errors": null
+                }
+                """
+                    )
+            )
+    )
     @GetMapping("/{id}")
     public ResponseEntity<PartidaResponseDTO> buscarPartidaPorId(@PathVariable Long id) {
         Partida partidaRetornada = buscarPartidaService.buscarPartidaPorId(id);
@@ -27,14 +91,123 @@ public class BuscarPartidaApiController {
                 .body(PartidaResponseMapper.toPartidaResponseDTO(partidaRetornada));
     }
 
+    @Operation(
+            summary = "Lista partidas por filtros",
+            description = "Retorna página de partidas filtrando por clubeId, estadioId, goleada, mandante, visitante. Suporta paginação."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Lista paginada de partidas",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PartidaResponseDTO.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "lista-com-resultados",
+                                    summary = "Partidas encontradas",
+                                    value = """
+                    {
+                        "content": [
+                            {
+                                "clubeMandante": {
+                                    "nome": "Clube Mandante",
+                                    "siglaEstado": "AM",
+                                    "dataCriacao": "2025-05-13"
+                                },
+                                "clubeVisitante": {
+                                    "nome": "Clube Visitante",
+                                    "siglaEstado": "AP",
+                                    "dataCriacao": "2025-05-13"
+                                },
+                                "estadio": {
+                                    "nome": "Estadio Exemplo"
+                                },
+                                "golsMandante": 2,
+                                "golsVisitante": 1,
+                                "dataHora": "10/06/2025 21:00:00",
+                                "resultado": "VITORIA_MANDANTE"
+                            }
+                        ],
+                        "pageable": {
+                            "pageNumber": 0,
+                            "pageSize": 20,
+                            "sort": {
+                                "empty": true,
+                                "sorted": false,
+                                "unsorted": true
+                            },
+                            "offset": 0,
+                            "paged": true,
+                            "unpaged": false
+                        },
+                        "last": true,
+                        "totalElements": 1,
+                        "totalPages": 1,
+                        "first": true,
+                        "size": 20,
+                        "number": 0,
+                        "sort": {
+                            "empty": true,
+                            "sorted": false,
+                            "unsorted": true
+                        },
+                        "numberOfElements": 1,
+                        "empty": false
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "lista-vazia",
+                                    summary = "Nenhuma partida encontrada para os filtros",
+                                    value = """
+                    {
+                        "content": [],
+                        "pageable": {
+                            "pageNumber": 0,
+                            "pageSize": 20,
+                            "sort": {
+                                "empty": true,
+                                "sorted": false,
+                                "unsorted": true
+                            },
+                            "offset": 0,
+                            "paged": true,
+                            "unpaged": false
+                        },
+                        "last": true,
+                        "totalElements": 0,
+                        "totalPages": 0,
+                        "first": true,
+                        "size": 20,
+                        "number": 0,
+                        "sort": {
+                            "empty": true,
+                            "sorted": false,
+                            "unsorted": true
+                        },
+                        "numberOfElements": 0,
+                        "empty": true
+                    }
+                    """
+                            )
+                    }
+            )
+    )
     @GetMapping
     public Page<PartidaResponseDTO> listarPartidas(
+            @Parameter(description = "ID do clube para filtragem", example = "1")
             @RequestParam(required = false) Long clubeId,
+            @Parameter(description = "ID do estádio para filtragem", example = "1")
             @RequestParam(required = false) Long estadioId,
+            @Parameter(description = "Filtrar apenas partidas consideradas goleada", example = "true")
             @RequestParam(required = false) Boolean goleada,
             @RequestParam(required = false) Boolean mandante,
             @RequestParam(required = false) Boolean visitante,
-            Pageable pageable
+            @Parameter(
+                    description = "Campo para ordenação, por padrão já está dataHora, asc",
+                    example = "[\"\"]"
+            )
+            @PageableDefault(sort = "dataHora", direction = Sort.Direction.ASC) Pageable pageable
     ) {
         return buscarPartidaService.listarPartidasFiltradas(clubeId, estadioId, goleada, mandante, visitante, pageable)
                 .map(PartidaResponseMapper::toPartidaResponseDTO);

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/CriarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/CriarPartidaApiController.java
@@ -1,10 +1,17 @@
 package br.com.meli.teamcubation_partidas_de_futebol.partida.controller;
 
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.dto.CriarPartidaRequestDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.dto.PartidaResponseDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.dto.mapper.PartidaResponseMapper;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.model.Partida;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.service.CriarPartidaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Partidas")
 @RestController
 @RequestMapping("/api/partida/criar")
 public class CriarPartidaApiController {
@@ -22,6 +30,171 @@ public class CriarPartidaApiController {
         this.criarPartidaService = criarPartidaService;
     }
 
+    @Operation(
+            summary = "Cadastra uma nova partida",
+            description = "Cria uma partida informando clubes, estádio, gols e data/hora. Retorna 201 ao sucesso. Aplica todas regras com mensagens claras para cenários inválidos."
+    )
+    @ApiResponse(
+            responseCode = "201",
+            description = "Partida criada com sucesso",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PartidaResponseDTO.class),
+                    examples = @ExampleObject(
+                            value = """
+                {
+                    "clubeMandante": {
+                        "nome": "clube de time criado",
+                        "siglaEstado": "AM",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "clubeVisitante": {
+                        "nome": "clube de time dois",
+                        "siglaEstado": "AP",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "estadio": {
+                        "nome": "Estadio Exemplo"
+                    },
+                    "golsMandante": 2,
+                    "golsVisitante": 1,
+                    "dataHora": "10/06/2025 21:00:00",
+                    "resultado": "VITORIA_MANDANTE"
+                }
+                """
+                    )
+            )
+    )
+    @ApiResponse(
+            responseCode = "400",
+            description = "Dados inválidos (campos obrigatórios, gols negativos, data futura, clubes iguais)",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "campos-invalidos",
+                                    summary = "Campos obrigatórios não informados ou inválidos",
+                                    value = """
+                    {
+                        "codigoErro": "CAMPO_INVALIDO",
+                        "dataHora": "04/08/2025 22:31:14",
+                        "mensagem": "Invalid request content.",
+                        "errors": {
+                            "golsMandante": "O número de gols do mandante não pode ser negativo",
+                            "golsVisitante": "O número de gols do visitante não pode ser negativo",
+                            "dataHora": "A data da partida não pode ser futura"
+                        }
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "clubes-iguais",
+                                    summary = "Clubes mandante e visitante iguais",
+                                    value = """
+                    {
+                        "codigoErro": "CLUBES_IGUAIS",
+                        "dataHora": "04/08/2025 22:32:29",
+                        "mensagem": "Não é possível criar partida pois os clubes são iguais.",
+                        "errors": null
+                    }
+                    """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "409",
+            description = "Conflitos de negócio: data anterior à criação de clube, clube inativo, partidas próximas, estádio já ocupado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "data-antes-criacao-clube",
+                                    summary = "Data da partida anterior à criação de clube",
+                                    value = """
+                    {
+                        "codigoErro": "DATA_PARTIDA_ANTERIOR_A_CRIACAO_DO_CLUBE",
+                        "dataHora": "04/08/2025 22:37:22",
+                        "mensagem": "Não pode cadastrar uma partida para uma data anterior à data de criação do clube.",
+                        "errors": null
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "clube-inativo",
+                                    summary = "Clube envolvido está inativo",
+                                    value = """
+                    {
+                        "codigoErro": "CLUBE_INATIVO",
+                        "dataHora": "04/08/2025 22:38:08",
+                        "mensagem": "Não é possível criar a partida pois há um clube inativo.",
+                        "errors": null
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "partidas-menor-48h",
+                                    summary = "Clube com outras partidas em menos de 48h",
+                                    value = """
+                    {
+                        "codigoErro": "CLUBE_TEM_PARTIDAS_COM_DATA_MENOR_QUE_48_HORAS_DA_NOVA_PARTIDA",
+                        "dataHora": "04/08/2025 22:39:10",
+                        "mensagem": "Não é possível criar a partida pois um dos clubes já possui uma partida cadastrada em menos de 48 horas desta data.",
+                        "errors": null
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "estadio-ja-tem-partida-no-dia",
+                                    summary = "Estádio já possui partida marcada para o mesmo dia",
+                                    value = """
+                    {
+                        "codigoErro": "ESTADIO_JA_POSSUI_PARTIDA_MARCADA_NO_MESMO_DIA",
+                        "dataHora": "04/08/2025 22:40:24",
+                        "mensagem": "Não é possível criar a partida pois no estádio já tem uma partida marcada para o mesmo dia.",
+                        "errors": null
+                    }
+                    """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Clube ou estádio não encontrado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "clube-nao-encontrado",
+                                    summary = "Clube não encontrado",
+                                    value = """
+                    {
+                        "codigoErro": "CLUBE_NAO_ENCONTRADO",
+                        "dataHora": "04/08/2025 19:27:34",
+                        "mensagem": "Clube com id 999 não encontrado.",
+                        "errors": null
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "estadio-nao-encontrado",
+                                    summary = "Estádio não encontrado",
+                                    value = """
+                    {
+                        "codigoErro": "ESTADIO_NAO_ENCONTRADO",
+                        "dataHora": "04/08/2025 19:28:03",
+                        "mensagem": "Estádio com id 999 não encontrado.",
+                        "errors": null
+                    }
+                    """
+                            )
+                    }
+            )
+    )
     @PostMapping
     public ResponseEntity<PartidaResponseDTO> criar(@RequestBody @Valid CriarPartidaRequestDTO criarPartidaRequestDTO) {
         Partida partidaCriada = criarPartidaService.criarPartida(criarPartidaRequestDTO);

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/CriarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/CriarPartidaApiController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Partidas")
 @RestController
-@RequestMapping("/api/partida/criar")
+@RequestMapping(value = "/api/partida/criar", produces = MediaType.APPLICATION_JSON_VALUE, consumes = MediaType.APPLICATION_JSON_VALUE)
 public class CriarPartidaApiController {
     private final CriarPartidaService criarPartidaService;
 
@@ -38,7 +39,6 @@ public class CriarPartidaApiController {
             responseCode = "201",
             description = "Partida criada com sucesso",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = PartidaResponseDTO.class),
                     examples = @ExampleObject(
                             value = """
@@ -69,7 +69,6 @@ public class CriarPartidaApiController {
             responseCode = "400",
             description = "Dados inválidos (campos obrigatórios, gols negativos, data futura, clubes iguais)",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = {
                             @ExampleObject(
@@ -107,7 +106,6 @@ public class CriarPartidaApiController {
             responseCode = "409",
             description = "Conflitos de negócio: data anterior à criação de clube, clube inativo, partidas próximas, estádio já ocupado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = {
                             @ExampleObject(
@@ -165,7 +163,6 @@ public class CriarPartidaApiController {
             responseCode = "404",
             description = "Clube ou estádio não encontrado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = {
                             @ExampleObject(

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/DeletarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/DeletarPartidaApiController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -18,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Partidas")
 @RestController
-@RequestMapping("/api/partida/deletar")
+@RequestMapping(value = "/api/partida/deletar", produces = MediaType.APPLICATION_JSON_VALUE)
 public class DeletarPartidaApiController {
     private final DeletarPartidaService deletarPartidaService;
 
@@ -38,7 +39,6 @@ public class DeletarPartidaApiController {
             responseCode = "404",
             description = "Partida não encontrada",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             name = "partida-nao-encontrada",
@@ -54,7 +54,7 @@ public class DeletarPartidaApiController {
                     )
             )
     )
-    @DeleteMapping("/{id}")
+    @DeleteMapping(value = "/{id}")
     public ResponseEntity<Void> deletarPartidaPorId(
             @Parameter(description = "ID da partida a ser excluída", example = "1")
             @PathVariable Long id) {

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/DeletarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/DeletarPartidaApiController.java
@@ -1,6 +1,14 @@
 package br.com.meli.teamcubation_partidas_de_futebol.partida.controller;
 
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.service.DeletarPartidaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -8,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Partidas")
 @RestController
 @RequestMapping("/api/partida/deletar")
 public class DeletarPartidaApiController {
@@ -17,8 +26,39 @@ public class DeletarPartidaApiController {
         this.deletarPartidaService = deletarPartidaService;
     }
 
+    @Operation(
+            summary = "Deleta uma partida",
+            description = "Remove definitivamente uma partida pelo ID. Retorna 204 NO CONTENT se sucesso. Caso não exista, retorna 404 NOT FOUND."
+    )
+    @ApiResponse(
+            responseCode = "204",
+            description = "Partida deletada com sucesso"
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Partida não encontrada",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            name = "partida-nao-encontrada",
+                            summary = "Partida não encontrada",
+                            value = """
+            {
+                "codigoErro": "PARTIDA_NAO_ENCONTRADA",
+                "dataHora": "04/08/2025 23:05:00",
+                "mensagem": "Partida com id 999 não encontrada.",
+                "errors": null
+            }
+            """
+                    )
+            )
+    )
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deletarPartidaPorId(@PathVariable Long id) {
+    public ResponseEntity<Void> deletarPartidaPorId(
+            @Parameter(description = "ID da partida a ser excluída", example = "1")
+            @PathVariable Long id) {
+
         deletarPartidaService.deletarPartidaPorId(id);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/dto/AtualizarPartidaRequestDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/dto/AtualizarPartidaRequestDTO.java
@@ -1,30 +1,38 @@
 package br.com.meli.teamcubation_partidas_de_futebol.partida.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.PositiveOrZero;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "Dados para atualizar uma partida já cadastrada")
 public class AtualizarPartidaRequestDTO {
+    @Schema(description = "ID do clube mandante", example = "1")
     @NotNull(message = "O clube mandante é obrigatório")
     private Long clubeMandanteId;
 
+    @Schema(description = "ID do clube visitante", example = "2")
     @NotNull(message = "O clube visitante é obrigatório")
     private Long clubeVisitanteId;
 
+    @Schema(description = "ID do estádio", example = "10")
     @NotNull(message = "O estádio é obrigatório")
     private Long estadioId;
 
+    @Schema(description = "Gols do mandante (não pode ser negativo)", example = "2")
     @PositiveOrZero(message = "O número de gols do mandante não pode ser negativo")
     private int golsMandante;
 
+    @Schema(description = "Gols do visitante (não pode ser negativo)", example = "1")
     @PositiveOrZero(message = "O número de gols do visitante não pode ser negativo")
     private int golsVisitante;
 
+    @Schema(description = "Data e hora da partida", example = "2025-06-10T21:00:00", type = "string", format = "date-time")
     @NotNull(message = "A data e hora da partida são obrigatórias")
     @PastOrPresent(message = "A data da partida não pode ser futura")
-    LocalDateTime dataHora;
+    private LocalDateTime dataHora;
 
     public AtualizarPartidaRequestDTO(Long clubeMandanteId, Long clubeVisitanteId, Long estadioId, int golsMandante, int golsVisitante, LocalDateTime dataHora) {
         this.clubeMandanteId = clubeMandanteId;

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/dto/CriarPartidaRequestDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/dto/CriarPartidaRequestDTO.java
@@ -1,30 +1,38 @@
 package br.com.meli.teamcubation_partidas_de_futebol.partida.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
 import jakarta.validation.constraints.PositiveOrZero;
 
 import java.time.LocalDateTime;
 
+@Schema(description = "Dados para criar uma nova partida")
 public class CriarPartidaRequestDTO {
+    @Schema(description = "ID do clube mandante", example = "1")
     @NotNull(message = "O clube mandante é obrigatório")
     private Long clubeMandanteId;
 
+    @Schema(description = "ID do clube visitante", example = "2")
     @NotNull(message = "O clube visitante é obrigatório")
     private Long clubeVisitanteId;
 
+    @Schema(description = "ID do estádio", example = "10")
     @NotNull(message = "O estádio é obrigatório")
     private Long estadioId;
 
+    @Schema(description = "Gols do mandante (não pode ser negativo)", example = "2")
     @PositiveOrZero(message = "O número de gols do mandante não pode ser negativo")
     private int golsMandante;
 
+    @Schema(description = "Gols do visitante (não pode ser negativo)", example = "1")
     @PositiveOrZero(message = "O número de gols do visitante não pode ser negativo")
     private int golsVisitante;
 
+    @Schema(description = "Data e hora da partida", example = "2025-06-10T21:00:00", type = "string", format = "date-time")
     @NotNull(message = "A data e hora da partida são obrigatórias")
     @PastOrPresent(message = "A data da partida não pode ser futura")
-    LocalDateTime dataHora;
+    private LocalDateTime dataHora;
 
     public CriarPartidaRequestDTO(Long clubeMandanteId, Long clubeVisitanteId, Long estadioId, int golsMandante, int golsVisitante, LocalDateTime dataHora) {
         this.clubeMandanteId = clubeMandanteId;

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/dto/PartidaResponseDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/dto/PartidaResponseDTO.java
@@ -5,17 +5,31 @@ import br.com.meli.teamcubation_partidas_de_futebol.estadio.dto.EstadioResponseD
 import br.com.meli.teamcubation_partidas_de_futebol.partida.util.Resultado;
 import br.com.meli.teamcubation_partidas_de_futebol.util.FormatadorDeData;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
-
+@Schema(description = "Dados de resposta de uma partida cadastrada ou consultada")
 public class PartidaResponseDTO {
+    @Schema(description = "Dados do clube mandante da partida")
     private ClubeResponseDTO clubeMandante;
+
+    @Schema(description = "Dados do clube visitante da partida")
     private ClubeResponseDTO clubeVisitante;
+
+    @Schema(description = "Estádio onde a partida ocorreu")
     private EstadioResponseDTO estadio;
+
+    @Schema(description = "Gols marcados pelo mandante", example = "2")
     private int golsMandante;
+
+    @Schema(description = "Gols marcados pelo visitante", example = "1")
     private int golsVisitante;
+
+    @Schema(description = "Data e hora da partida", example = "04/08/2025 18:35:13", type = "string", format = "date-time")
     @JsonFormat(pattern = FormatadorDeData.PADRAO_DATA_HORA)
     private LocalDateTime dataHora;
+
+    @Schema(description = "Resultado da partida: VITORIA_MANDANTE, VITORIA_VISITANTE ou EMPATE", example = "VITORIA_MANDANTE")
     private Resultado resultado;
 
     public PartidaResponseDTO() {

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/ranking/controller/RankingApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/ranking/controller/RankingApiController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +21,7 @@ import java.util.List;
 
 @Tag(name = "Ranking")
 @RestController
-@RequestMapping("/api/clube/ranking")
+@RequestMapping(value = "/api/clube/ranking", produces = MediaType.APPLICATION_JSON_VALUE)
 public class RankingApiController {
     private final RankingService rankingService;
 
@@ -43,7 +44,6 @@ public class RankingApiController {
             responseCode = "200",
             description = "Ranking retornado com sucesso",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = Ranking.class),
                     examples = {
                             @ExampleObject(

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/ranking/controller/RankingApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/ranking/controller/RankingApiController.java
@@ -2,6 +2,13 @@ package br.com.meli.teamcubation_partidas_de_futebol.ranking.controller;
 
 import br.com.meli.teamcubation_partidas_de_futebol.ranking.model.Ranking;
 import br.com.meli.teamcubation_partidas_de_futebol.ranking.service.RankingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "Ranking")
 @RestController
 @RequestMapping("/api/clube/ranking")
 public class RankingApiController {
@@ -20,9 +28,91 @@ public class RankingApiController {
         this.rankingService = rankingService;
     }
 
+    @Operation(
+            summary = "Obtém ranking de clubes conforme o critério",
+            description = """
+        Retorna ranking dos clubes ordenado conforme critério escolhido (tipoRanking):
+        - TOTAL_PONTOS (pontos, vitória=3, empate=1)
+        - TOTAL_VITORIAS
+        - TOTAL_GOLS
+        - TOTAL_JOGOS
+        - Uma lista vazia é retornada caso não existam clubes para o ranking solicitado.
+        """
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Ranking retornado com sucesso",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = Ranking.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "TOTAL_PONTOS",
+                                    summary = "Ranking por total de pontos",
+                                    value = """
+                    [
+                        {"nomeClube": "aclube de time", "estadoClube": "AP", "total": 6},
+                        {"nomeClube": "clube de time criado", "estadoClube": "SP", "total": 6},
+                        {"nomeClube": "Clube de Exemplo Um", "estadoClube": "AM", "total": 6},
+                        {"nomeClube": "time teste", "estadoClube": "SP", "total": 5},
+                        {"nomeClube": "clube de time atualizado", "estadoClube": "AM", "total": 4}
+                    ]
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "TOTAL_VITORIAS",
+                                    summary = "Ranking por total de vitórias",
+                                    value = """
+                    [
+                        {"nomeClube": "aclube de time", "estadoClube": "AP", "total": 2},
+                        {"nomeClube": "clube de time criado", "estadoClube": "SP", "total": 2},
+                        {"nomeClube": "Clube de Exemplo Um", "estadoClube": "AM", "total": 2},
+                        {"nomeClube": "clube de time atualizado", "estadoClube": "AM", "total": 1},
+                        {"nomeClube": "clube de time criado", "estadoClube": "SC", "total": 1}
+                    ]
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "TOTAL_GOLS",
+                                    summary = "Ranking por total de gols",
+                                    value = """
+                    [
+                        {"nomeClube": "aclube de time", "estadoClube": "AP", "total": 10},
+                        {"nomeClube": "time teste", "estadoClube": "SP", "total": 8},
+                        {"nomeClube": "clube de time criado", "estadoClube": "SP", "total": 7},
+                        {"nomeClube": "Clube de Exemplo Um", "estadoClube": "AM", "total": 7},
+                        {"nomeClube": "clube de time atualizado", "estadoClube": "AM", "total": 6}
+                    ]
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "TOTAL_JOGOS",
+                                    summary = "Ranking por total de jogos",
+                                    value = """
+                    [
+                        {"nomeClube": "clube de time atualizado", "estadoClube": "AM", "total": 4},
+                        {"nomeClube": "aclube de time", "estadoClube": "AP", "total": 4},
+                        {"nomeClube": "clube de time", "estadoClube": "AP", "total": 3},
+                        {"nomeClube": "time teste", "estadoClube": "SP", "total": 3},
+                        {"nomeClube": "clube de time criado", "estadoClube": "SP", "total": 2}
+                    ]
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "lista-vazia",
+                                    summary = "Nenhum clube atende ao critério",
+                                    value = "[]"
+                            )
+                    }
+            )
+    )
     @GetMapping
     public ResponseEntity<List<? extends Ranking>> calcularRanking
-            (@RequestParam("tipoRanking") String tipoRankingString) {
+            ( @Parameter(
+                    description = "Critério do ranking: TOTAL_PONTOS, TOTAL_VITORIAS, TOTAL_GOLS ou TOTAL_JOGOS",
+                    example = "TOTAL_PONTOS"
+            )
+                    @RequestParam("tipoRanking") String tipoRankingString) {
         List<? extends Ranking> ranking = rankingService.calcularRanking(tipoRankingString);
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/ranking/model/Ranking.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/ranking/model/Ranking.java
@@ -2,10 +2,17 @@ package br.com.meli.teamcubation_partidas_de_futebol.ranking.model;
 
 import br.com.meli.teamcubation_partidas_de_futebol.clube.model.Clube;
 import br.com.meli.teamcubation_partidas_de_futebol.retrospecto.model.Retrospecto;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "Item de ranking de clubes, contendo nome do clube, UF e total computado (pontos, gols, vitórias ou jogos)")
 public abstract class Ranking {
+    @Schema(description = "Nome do clube", example = "Clube de Exemplo Um")
     private final String nomeClube;
+
+    @Schema(description = "Sigla do estado do clube", example = "AM")
     private final String estadoClube;
+
+    @Schema(description = "Total do ranking (pontos, gols, vitórias ou jogos)", example = "10")
     private final int total;
 
     public Ranking(Clube clube, Retrospecto retrospecto) {

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/controller/BuscarRetrospectoApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/controller/BuscarRetrospectoApiController.java
@@ -13,12 +13,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Retrospecto")
 @RestController
-@RequestMapping("/api/clube")
+@RequestMapping(value = "/api/clube", produces = MediaType.APPLICATION_JSON_VALUE)
 public class BuscarRetrospectoApiController {
     private final BuscarRetrospectoService buscarRetrospectoService;
 
@@ -34,7 +35,6 @@ public class BuscarRetrospectoApiController {
             responseCode = "200",
             description = "Retrospecto retornado com sucesso",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = Retrospecto.class),
                     examples = {
                             @ExampleObject(
@@ -82,7 +82,6 @@ public class BuscarRetrospectoApiController {
             responseCode = "404",
             description = "Clube não encontrado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             value = """
@@ -118,7 +117,6 @@ public class BuscarRetrospectoApiController {
             responseCode = "200",
             description = "Retrospecto contra adversários retornado com sucesso",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = RetrospectoAdversariosResponseDTO.class),
                     examples = {
                             @ExampleObject(
@@ -181,7 +179,6 @@ public class BuscarRetrospectoApiController {
             responseCode = "404",
             description = "Clube não encontrado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             value = """
@@ -220,7 +217,6 @@ public class BuscarRetrospectoApiController {
             responseCode = "200",
             description = "Confronto encontrado ou ambos clubes com retrospecto zerado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = RetrospectoConfronto.class),
                     examples = {
                             @ExampleObject(
@@ -343,7 +339,6 @@ public class BuscarRetrospectoApiController {
             responseCode = "404",
             description = "Um dos clubes não encontrado",
             content = @Content(
-                    mediaType = "application/json",
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             value = """

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/controller/BuscarRetrospectoApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/controller/BuscarRetrospectoApiController.java
@@ -1,13 +1,22 @@
 package br.com.meli.teamcubation_partidas_de_futebol.retrospecto.controller;
 
+import br.com.meli.teamcubation_partidas_de_futebol.global_exception.ErroPadrao;
 import br.com.meli.teamcubation_partidas_de_futebol.retrospecto.dto.RetrospectoAdversariosResponseDTO;
 import br.com.meli.teamcubation_partidas_de_futebol.retrospecto.model.Retrospecto;
 import br.com.meli.teamcubation_partidas_de_futebol.retrospecto.model.RetrospectoConfronto;
 import br.com.meli.teamcubation_partidas_de_futebol.retrospecto.service.BuscarRetrospectoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Retrospecto")
 @RestController
 @RequestMapping("/api/clube")
 public class BuscarRetrospectoApiController {
@@ -17,10 +26,83 @@ public class BuscarRetrospectoApiController {
         this.buscarRetrospectoService = buscarRetrospectoService;
     }
 
+    @Operation(
+            summary = "Busca o retrospecto geral de um clube",
+            description = "Retorna dados agregados de jogos, vitórias, empates, derrotas, gols feitos e sofridos. Retorna campos zerados se não houver partidas. 404 se clube não existe."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Retrospecto retornado com sucesso",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = Retrospecto.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "com-jogos",
+                                    summary = "Clube com partidas registradas",
+                                    value = """
+                    {
+                        "clube": {
+                            "nome": "clube de time atualizado",
+                            "siglaEstado": "AM",
+                            "dataCriacao": "2025-05-13"
+                        },
+                        "jogos": 4,
+                        "vitorias": 1,
+                        "derrotas": 2,
+                        "empates": 1,
+                        "golsFeitos": 6,
+                        "golsSofridos": 11
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "sem-jogos",
+                                    summary = "Clube sem partidas (todos campos zerados)",
+                                    value = """
+                    {
+                        "clube": {
+                            "nome": "clube de time quatro atualizado",
+                            "siglaEstado": "SP",
+                            "dataCriacao": "2025-05-13"
+                        },
+                        "jogos": 0,
+                        "vitorias": 0,
+                        "derrotas": 0,
+                        "empates": 0,
+                        "golsFeitos": 0,
+                        "golsSofridos": 0
+                    }
+                    """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Clube não encontrado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            value = """
+                    {
+                        "codigoErro": "CLUBE_NAO_ENCONTRADO",
+                        "dataHora": "05/08/2025 14:41:46",
+                        "mensagem": "Clube com id 999 não encontrado.",
+                        "errors": null
+                    }
+                    """
+                    )
+            )
+    )
     @GetMapping("/{id}/retrospecto")
-    public ResponseEntity<Retrospecto> buscar
-            (@PathVariable Long id,
+    public ResponseEntity<Retrospecto> buscarRetrospectoTotalDeUmClube
+            (@Parameter(description = "ID do clube", example = "1")
+             @PathVariable Long id,
+             @Parameter(description = "Filtrar só partidas como mandante", example = "true")
              @RequestParam(required = false) Boolean mandante,
+             @Parameter(description = "Filtrar só partidas como visitante", example = "false")
              @RequestParam(required = false) Boolean visitante){
         Retrospecto retrospecto = buscarRetrospectoService.buscarRetrospectoClube(id, mandante, visitante);
         return ResponseEntity
@@ -28,10 +110,98 @@ public class BuscarRetrospectoApiController {
                 .body(retrospecto);
     }
 
+    @Operation(
+            summary = "Busca retrospecto de um clube contra todos adversários",
+            description = "Mostra resumo de partidas, vitórias, empates, derrotas, gols feitos/sofridos por adversário. Retorna lista vazia se não houver confrontos. 404 caso o clube não exista."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Retrospecto contra adversários retornado com sucesso",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = RetrospectoAdversariosResponseDTO.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "com-adversarios",
+                                    summary = "Lista de retrospectos para adversários",
+                                    value = """
+                    {
+                        "nomeClube": "clube de time atualizado",
+                        "estadoClube": "AM",
+                        "retrospectoContraAdversarios": [
+                            {
+                                "nomeAdversario": "aclube de time",
+                                "estadoAdversario": "AP",
+                                "jogos": 1,
+                                "vitorias": 0,
+                                "derrotas": 1,
+                                "empates": 0,
+                                "golsFeitos": 1,
+                                "golsSofridos": 4
+                            },
+                            {
+                                "nomeAdversario": "clube de time",
+                                "estadoAdversario": "AP",
+                                "jogos": 2,
+                                "vitorias": 1,
+                                "derrotas": 0,
+                                "empates": 1,
+                                "golsFeitos": 4,
+                                "golsSofridos": 3
+                            },
+                            {
+                                "nomeAdversario": "time teste",
+                                "estadoAdversario": "SP",
+                                "jogos": 1,
+                                "vitorias": 0,
+                                "derrotas": 1,
+                                "empates": 0,
+                                "golsFeitos": 1,
+                                "golsSofridos": 4
+                            }
+                        ]
+                    }
+                    """
+                            ),
+                            @ExampleObject(
+                                    name = "sem-adversarios",
+                                    summary = "Clube sem confrontos (lista vazia)",
+                                    value = """
+                    {
+                        "nomeClube": "clube de time quatro atualizado",
+                        "estadoClube": "SP",
+                        "retrospectoContraAdversarios": []
+                    }
+                    """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Clube não encontrado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            value = """
+                    {
+                        "codigoErro": "CLUBE_NAO_ENCONTRADO",
+                        "dataHora": "05/08/2025 14:51:33",
+                        "mensagem": "Clube com id 999 não encontrado.",
+                        "errors": null
+                    }
+                    """
+                    )
+            )
+    )
     @GetMapping("/{id}/retrospectos-adversarios")
     public ResponseEntity<RetrospectoAdversariosResponseDTO> buscarContraAdversarios
-            (@PathVariable Long id,
+            (@Parameter(description = "ID do clube", example = "1")
+             @PathVariable Long id,
+             @Parameter(description = "Filtrar só partidas como mandante", example = "true")
              @RequestParam(required = false) Boolean mandante,
+             @Parameter(description = "Filtrar só partidas como visitante", example = "false")
              @RequestParam(required = false) Boolean visitante)
     {
         RetrospectoAdversariosResponseDTO retrospectosDTO =
@@ -42,9 +212,156 @@ public class BuscarRetrospectoApiController {
                 .body(retrospectosDTO);
     }
 
+    @Operation(
+            summary = "Busca retrospecto de confrontos diretos entre dois clubes",
+            description = "Retorna retrospecto consolidado e lista de partidas entre dois clubes. Lista vazia e campos zerados se sem confrontos. 404 caso qualquer clube não exista."
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Confronto encontrado ou ambos clubes com retrospecto zerado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = RetrospectoConfronto.class),
+                    examples = {
+                            @ExampleObject(
+                                    name = "com-partidas",
+                                    summary = "Retrospecto com confrontos",
+                                    value = """
+        {
+            "retrospectos": [
+                {
+                    "clube": {
+                        "nome": "clube de time atualizado",
+                        "siglaEstado": "AM",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "jogos": 2,
+                    "vitorias": 1,
+                    "derrotas": 0,
+                    "empates": 1,
+                    "golsFeitos": 4,
+                    "golsSofridos": 3
+                },
+                {
+                    "clube": {
+                        "nome": "clube de time",
+                        "siglaEstado": "AP",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "jogos": 2,
+                    "vitorias": 0,
+                    "derrotas": 1,
+                    "empates": 1,
+                    "golsFeitos": 3,
+                    "golsSofridos": 4
+                }
+            ],
+            "partidas": [
+                {
+                    "clubeMandante": {
+                        "nome": "clube de time atualizado",
+                        "siglaEstado": "AM",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "clubeVisitante": {
+                        "nome": "clube de time",
+                        "siglaEstado": "AP",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "estadio": {
+                        "nome": "Estadio de time atualizado com cep meli"
+                    },
+                    "golsMandante": 1,
+                    "golsVisitante": 1,
+                    "dataHora": "04/08/2025 18:35:13",
+                    "resultado": "EMPATE"
+                },
+                {
+                    "clubeMandante": {
+                        "nome": "clube de time atualizado",
+                        "siglaEstado": "AM",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "clubeVisitante": {
+                        "nome": "clube de time",
+                        "siglaEstado": "AP",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "estadio": {
+                        "nome": "Estadio de time atualizado com cep meli"
+                    },
+                    "golsMandante": 3,
+                    "golsVisitante": 2,
+                    "dataHora": "05/06/2025 21:00:00",
+                    "resultado": "VITORIA_MANDANTE"
+                }
+            ]
+        }
+        """
+                            ),
+                            @ExampleObject(
+                                    name = "sem-partidas",
+                                    summary = "Não existe confronto, ambos clubes e retrospectos zerados",
+                                    value = """
+        {
+            "retrospectos": [
+                {
+                    "clube": {
+                        "nome": "clube de time atualizado",
+                        "siglaEstado": "AM",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "jogos": 0,
+                    "vitorias": 0,
+                    "derrotas": 0,
+                    "empates": 0,
+                    "golsFeitos": 0,
+                    "golsSofridos": 0
+                },
+                {
+                    "clube": {
+                        "nome": "clube de time quatro atualizado",
+                        "siglaEstado": "SP",
+                        "dataCriacao": "2025-05-13"
+                    },
+                    "jogos": 0,
+                    "vitorias": 0,
+                    "derrotas": 0,
+                    "empates": 0,
+                    "golsFeitos": 0,
+                    "golsSofridos": 0
+                }
+            ],
+            "partidas": []
+        }
+        """
+                            )
+                    }
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Um dos clubes não encontrado",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            value = """
+                    {
+                        "codigoErro": "CLUBE_NAO_ENCONTRADO",
+                        "dataHora": "05/08/2025 14:57:51",
+                        "mensagem": "Clube com id 999 não encontrado.",
+                        "errors": null
+                    }
+                    """
+                    )
+            )
+    )
     @GetMapping("/{idClube}/confronto/{idAdversario}")
-    public ResponseEntity<RetrospectoConfronto> buscarRetrospectoContraAdversario(
+    public ResponseEntity<RetrospectoConfronto> buscarConfronto(
+            @Parameter(description = "ID do clube principal", example = "1")
             @PathVariable Long idClube,
+            @Parameter(description = "ID do adversário", example = "2")
             @PathVariable Long idAdversario
     ) {
         RetrospectoConfronto retrospectoConfronto = buscarRetrospectoService

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/dto/RetrospectoAdversariosResponseDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/dto/RetrospectoAdversariosResponseDTO.java
@@ -1,12 +1,22 @@
 package br.com.meli.teamcubation_partidas_de_futebol.retrospecto.dto;
 
 import br.com.meli.teamcubation_partidas_de_futebol.retrospecto.model.RetrospectoAdversario;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "Resposta com retrospecto de um clube contra todos seus adversários")
 public class RetrospectoAdversariosResponseDTO {
+    @Schema(description = "Nome do clube analisado", example = "Clube de Exemplo Um")
     private final String nomeClube;
+
+    @Schema(description = "Sigla do estado do clube", example = "SP")
     private final String estadoClube;
+
+    @Schema(
+            description = "Lista de retrospectos individuais contra cada adversário, trazendo jogos, vitórias, empates, derrotas, gols feitos e sofridos",
+            implementation = RetrospectoAdversario.class
+    )
     private final List<RetrospectoAdversario>  retrospectoContraAdversarios;
 
     public RetrospectoAdversariosResponseDTO(String nomeClube, String estadoClube, List<RetrospectoAdversario> retrospectoContraAdversarios) {

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/dto/RetrospectoConfrontoRequestDTO.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/dto/RetrospectoConfrontoRequestDTO.java
@@ -1,9 +1,14 @@
 package br.com.meli.teamcubation_partidas_de_futebol.retrospecto.dto;
 
-public class RetrospectoConfrontoRequestDTO {
-    private final Long clubeId;
-    private final Long adversarioId;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "Requisição para buscar o confronto direto entre dois clubes")
+public class RetrospectoConfrontoRequestDTO {
+    @Schema(description = "ID do clube principal", example = "1")
+    private final Long clubeId;
+
+    @Schema(description = "ID do clube adversário", example = "2")
+    private final Long adversarioId;
 
     public RetrospectoConfrontoRequestDTO(Long clubeId, Long adversarioId) {
         this.clubeId = clubeId;

--- a/partidas-de-futebol-api/src/test/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/controller/BuscarRetrospectoApiControllerTest.java
+++ b/partidas-de-futebol-api/src/test/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/controller/BuscarRetrospectoApiControllerTest.java
@@ -161,7 +161,7 @@ public class BuscarRetrospectoApiControllerTest {
             ",true",
             "true,true"
     })
-    void deveBuscarRetrospectoContraAdversario_comSucesso(Boolean mandante, Boolean visitante) throws Exception {
+    void deveBuscarRetrospectoTotalDeUmClubeConfronto_comSucesso(Boolean mandante, Boolean visitante) throws Exception {
         Long id = 1L;
         List<Partida> partidas = PartidaUtil.criarListPartidasComTesteUtils(2);
         Clube clube = partidas.getFirst().getClubeMandante();
@@ -228,7 +228,7 @@ public class BuscarRetrospectoApiControllerTest {
     }
 
     @Test
-    void deveRetornarNotFound_quandoClubeNaoExiste_aoBuscarRetrospectoContraAdversario() throws Exception {
+    void deveRetornarNotFound_quandoClubeNaoExiste_aoBuscarConfronto() throws Exception {
         Long id = 99L;
 
         Mockito.when(buscarRetrospectoService.buscarRetrospectoClubeContraAdversarios(
@@ -247,7 +247,7 @@ public class BuscarRetrospectoApiControllerTest {
     }
 
     @Test
-    void deveBuscarRetrospectoConfronto_comSucesso() throws Exception {
+    void deveBuscarRetrospectoTotalDeUmClubeRetrospectoConfronto_comSucesso() throws Exception {
         Long idClube = 1L;
         Long idAdversario = 2L;
         Clube clube = ClubeUtil.criarClube(idClube);

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,13 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- Swagger -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.9</version>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
# Pull Request: Documentação Swagger completa — Clubes, Estádios, Partidas e Buscas Avançadas

## Descrição

Este PR implementa a documentação Swagger/OpenAPI em todo o ecossistema da API REST Teamcubation, incluindo todos os principais recursos de gestão de clubes, estádios, partidas, ranking e buscas avançadas de retrospecto (1 a 4). A documentação foi feita com anotações detalhadas nas controllers, DTOs, respostas de erro e múltiplos exemplos por cenário. 

Todos os endpoints agora exibem no Swagger UI:
- Resposta 200 com exemplos reais para listas, buscas unitárias e cenários vazios.
- Parâmetros de filtros informativos, exemplos e valores esperados.
- Quadros de resposta 400, 404 e 409 documentados com estrutura de erro padronizada e exemplos de cada caso previsto.
- DTOs anotados com @Schema para descrever campos, exemplos e formatos, melhorando a clareza ao consumidor da API.

---

## Escopo documentado

### 1. Clubes
- Cadastro, atualização, busca, inativação/remoção e listagem detalhados em Swagger.
- Regras de validação específicas documentadas (campos obrigatórios, sigla do estado, data de criação, duplicidade de nome no estado etc).
- Exemplos customizados de requisição e resposta para sucesso, campos inválidos e cenários de erro.

### 2. Estádios
- Endpoints para criação, atualização, busca, deleção e listagem dos estádios cobertos com exemplos de sucesso e erros correspondentes (incluindo quando estádio não é encontrado ou nome duplicado).
- Schema dos DTOs de estádio documentados.

### 3. Partidas
- Inclusão, atualização, deleção (hard delete) e busca/listagem de partidas documentados, sempre com exemplos completos.
- Filtros de busca por clubeId, estadioId, goleada, mandante e visitante bem descritos.
- Regras de negócio para criação e atualização (datas, gols negativos, clube inativo, estádio ocupado, conflitos de horários) esclarecidas com exemplos de response 409 e 400.

### 4. Ranking (Strategy)
- Documentação do endpoint de ranking, aceitando parâmetro `tipoRanking` para retorno por TOTAL_PONTOS, TOTAL_VITORIAS, TOTAL_GOLS ou TOTAL_JOGOS.
- Exemplos de saída para cada critério via @ExampleObject e detalhamento do schema Ranking.

### 5. Retrospecto/Buscas avançadas (1 a 3)
- Busca avançada 1 (`/api/clube/{id}/retrospecto`): retrospecto geral do clube, cobrindo casos com partidas, zerado, e erro 404.
- Busca avançada 2 (`/api/clube/{id}/retrospectos-adversarios`): retrospecto do clube contra cada adversário, com exemplos para múltiplos adversários, lista vazia, e erro 404.
- Busca avançada 3 (`/api/clube/{idClube}/confronto/{idAdversario}`): confrontos diretos entre clubes detalhando ambos os retrospectos, lista de partidas, casos de ausência de confronto e erro para clube inexistente.
- Schemas dos DTOs de resposta das buscas avançadas documentados.

---

## Pontos de atenção/boas práticas aplicadas

- Utilização consistente de exemplos reais e diferentes para cada cenário de sucesso, vazio e erro.
- Detalhamento de todos os parâmetros dos endpoints, incluindo enums, filtros booleanos/combináveis e queryStrings de paginação/ordenação.
- Agrupamento de endpoints por tags funcionais (Clubes, Estádios, Partidas, Retrospecto, Ranking) no Swagger UI.
- Campos dos DTOs e modelos anotados com @Schema, descrevendo tipo, descrição e exemplos para facilitar geração e integração de clients.

---

## Resultado

O consumidor da API terá acesso a documentação precisa, clara e completa de todos os contratos REST e regras de negócio, facilitando integração, validação e manutenção do projeto.

---