### PR TITLE
Refactor/melhorias rabbit swagger

### DIFF
--- a/docs/api-erros-rest.md
+++ b/docs/api-erros-rest.md
@@ -1,0 +1,270 @@
+## 1. Clube (criação, atualização, busca, inativação – fluxos de sucesso e erro)
+
+#### **Descrição técnica**
+APIs RESTful para gerenciamento de clubes de futebol. Implementa cadastro, busca, atualização e inativação, aplicando validação automática (Bean Validation) e regras de negócio via services e validators. Controle centralizado de exceções. Erros retornam sempre com payload padronizado para tratamento no front ou integração.
+
+#### **Erros padrões de Clube**
+
+##### 1.1. Schema global de erro
+```json
+{
+  "codigoErro": "CLUBE_NAO_ENCONTRADO",
+  "dataHora": "2025-08-04T12:00:00",
+  "mensagem": "Mensagem legível ao consumidor.",
+  "errors": {
+    "campo": "Descrição do erro para o campo."
+  }
+}
+```
+
+##### 1.2. Mapas de códigos e exemplos de payloads
+
+- **CAMPO_INVALIDO** – violação de bean validation
+    - `400 Bad Request`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "CAMPO_INVALIDO",
+        "dataHora": "2025-08-04T11:02:56",
+        "mensagem": "Invalid request content.",
+        "errors": {
+          "siglaEstado": "A sigla do estado só pode ter 2 letras.",
+          "nome": "O nome tem que ter no minimo duas letras;",
+          "dataCriacao": "A data de criação não pode ser futura"
+        }
+      }
+      ```
+- **ESTADO_INEXISTENTE** – sigla de estado inválida
+    - `400 Bad Request`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "ESTADO_INEXISTENTE",
+        "dataHora": "2025-08-04T11:03:40",
+        "mensagem": "Não é possivel criar o clube pois o estado AX não existe.",
+        "errors": null
+      }
+      ```
+- **CLUBE_DUPLICADO** – tentava duplicar nome/estado já existente
+    - `409 Conflict`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "CLUBE_DUPLICADO",
+        "dataHora": "2025-08-04T11:04:33",
+        "mensagem": "Já existe clube com este nome no mesmo estado.",
+        "errors": null
+      }
+      ```
+- **CLUBE_NAO_ENCONTRADO** – id informado não existe
+    - `404 Not Found`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "CLUBE_NAO_ENCONTRADO",
+        "dataHora": "2025-08-04T11:52:23",
+        "mensagem": "Clube com id 999 não encontrado.",
+        "errors": null
+      }
+      ```
+- **DATA_CRIACAO_POSTERIOR_A_DATA_PARTIDA** – ao atualizar data para depois de partida existente
+    - `409 Conflict`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "DATA_CRIACAO_POSTERIOR_A_DATA_PARTIDA",
+        "dataHora": "2025-08-04T11:52:08",
+        "mensagem": "A data de criação do clube com id 1 está posterior a data de uma partida cadastrada.",
+        "errors": null
+      }
+      ```
+
+#### **Principais cenários cobertos**
+- Cadastro (`POST /api/clube/criar`): Erros de campo, estado, duplicidade
+- Atualização (`PUT /api/clube/atualizar/{id}`): Mesmos acima + data inválida, clube não encontrado
+- Busca (`GET /api/clube/buscar/{id}`): Clube não encontrado
+- Inativação (`DELETE /api/clube/inativar/{id}`): Clube não encontrado
+
+---
+
+## 2. Estádio (criação, atualização, busca – fluxos de sucesso e erro)
+
+#### **Descrição técnica**
+APIs RESTful para gerenciamento de estádios, contemplando cadastro, atualização (com busca automática do endereço via ViaCep), busca por critérios e inativação. Validação de nome e cep, tratamento dos principais erros de negócio e estrutura padronizada de erro.
+
+#### **Erros padrões de Estádio**
+
+- **CAMPO_INVALIDO** – qualquer falha de bean validation: nome ou cep inválido/nulo
+    - `400 Bad Request`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "CAMPO_INVALIDO",
+        "dataHora": "2025-08-04T16:18:54",
+        "mensagem": "Invalid request content.",
+        "errors": {
+          "nome": "não deve ser nulo",
+          "cep": "O cep deve conter exatamente 8 dígitos numéricos"
+        }
+      }
+      ```
+- **ESTADIO_JA_EXISTE** – nome duplicado
+    - `409 Conflict`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "ESTADIO_JA_EXISTE",
+        "dataHora": "2025-08-04T16:15:10",
+        "mensagem": "Já existe um estadio com este nome.",
+        "errors": null
+      }
+      ```
+- **ESTADIO_NAO_ENCONTRADO** – busca, atualização, deleção não encontra id
+    - `404 Not Found`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "ESTADIO_NAO_ENCONTRADO",
+        "dataHora": "2025-08-04T16:14:43",
+        "mensagem": "Estadio com id 999 não encontrado.",
+        "errors": null
+      }
+      ```
+
+#### **Principais cenários cobertos**
+- Cadastro (`POST /api/estadio/criar`)
+- Atualização (`PUT /api/estadio/atualizar/{id}`)
+- Busca detalhada (`GET /api/estadio/buscar/{id}`)
+- Busca paginada (`GET /api/estadio/buscar`): Apenas casos felizes/documentação externa para erros.
+- Todas as situações acima utilizam sempre o schema padrão de erro.
+
+---
+
+## 3. Partida (criação, atualização, busca, deleção – fluxos de sucesso e erro)
+
+#### **Descrição técnica**
+APIs RESTful para partidas de futebol, abrangendo cadastro, edição, busca (por filtros ou id) e deleção. Aplica todas as validações de negócio necessárias: clubes distintos, clubes/estádio existentes, datas válidas, conflitos de agendamento, etc. Controle unificado de exceções para respostas consistentes.
+
+#### **Erros padrões de Partida**
+
+- **CAMPO_INVALIDO** – campos obrigatórios ausentes, negativos, data futura
+    - `400 Bad Request`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "CAMPO_INVALIDO",
+        "dataHora": "2025-08-04T22:31:14",
+        "mensagem": "Invalid request content.",
+        "errors": {
+          "golsMandante": "O número de gols do mandante não pode ser negativo",
+          "dataHora": "A data da partida não pode ser futura"
+        }
+      }
+      ```
+- **CLUBES_IGUAIS** – mandante/visitante iguais
+    - `400 Bad Request`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "CLUBES_IGUAIS",
+        "dataHora": "2025-08-04T22:32:29",
+        "mensagem": "Não é possível criar partida pois os clubes são iguais.",
+        "errors": null
+      }
+      ```
+- **DATA_PARTIDA_ANTERIOR_A_CRIACAO_DO_CLUBE** – data da partida antes da criação do clube
+    - `409 Conflict`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "DATA_PARTIDA_ANTERIOR_A_CRIACAO_DO_CLUBE",
+        "dataHora": "2025-08-04T22:37:22",
+        "mensagem": "Não pode cadastrar uma partida para uma data anterior à data de criação do clube.",
+        "errors": null
+      }
+      ```
+- **CLUBE_INATIVO** – algum clube envolvido está inativo
+    - `409 Conflict`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "CLUBE_INATIVO",
+        "dataHora": "2025-08-04T22:38:08",
+        "mensagem": "Não é possível criar a partida pois há um clube inativo.",
+        "errors": null
+      }
+      ```
+- **CLUBE_TEM_PARTIDAS_COM_DATA_MENOR_QUE_48_HORAS_DA_NOVA_PARTIDA** – conflito por partidas anteriores próximas
+    - `409 Conflict`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "CLUBE_TEM_PARTIDAS_COM_DATA_MENOR_QUE_48_HORAS_DA_NOVA_PARTIDA",
+        "dataHora": "2025-08-04T22:39:10",
+        "mensagem": "Não é possível criar a partida pois um dos clubes já possui uma partida cadastrada em menos de 48 horas desta data.",
+        "errors": null
+      }
+      ```
+- **ESTADIO_JA_POSSUI_PARTIDA_MARCADA_NO_MESMO_DIA** – estádio já ocupado
+    - `409 Conflict`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "ESTADIO_JA_POSSUI_PARTIDA_MARCADA_NO_MESMO_DIA",
+        "dataHora": "2025-08-04T22:40:24",
+        "mensagem": "Não é possível criar a partida pois no estádio já tem uma partida marcada para o mesmo dia.",
+        "errors": null
+      }
+      ```
+- **CLUBE_NAO_ENCONTRADO** – id de clube não existe
+    - `404 Not Found`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "CLUBE_NAO_ENCONTRADO",
+        "dataHora": "2025-08-04T19:27:34",
+        "mensagem": "Clube com id 999 não encontrado.",
+        "errors": null
+      }
+      ```
+- **ESTADIO_NAO_ENCONTRADO** – estádio não existe
+    - `404 Not Found`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "ESTADIO_NAO_ENCONTRADO",
+        "dataHora": "2025-08-04T19:28:03",
+        "mensagem": "Estádio com id 999 não encontrado.",
+        "errors": null
+      }
+      ```
+- **PARTIDA_NAO_ENCONTRADA** – partida não existe (edição, deleção, busca)
+    - `404 Not Found`
+    - Exemplo:
+      ```json
+      {
+        "codigoErro": "PARTIDA_NAO_ENCONTRADA",
+        "dataHora": "2025-08-04T23:05:00",
+        "mensagem": "Partida com id 999 não encontrada.",
+        "errors": null
+      }
+      ```
+
+#### **Principais cenários cobertos**
+- Cadastro (`POST /api/partida/criar`): validador cobre campos, clubes, estádio, datas, regras de negócio
+- Atualização (`PUT /api/partida/atualizar/{id}`): mesmos erros possíveis do cadastro, mais partida não encontrada
+- Busca (`GET /api/partida/buscar/{id}`): partida não encontrada
+- Listagem paginada: Sem erro; casos de ausência retornam lista vazia e 200 OK
+- Deleção (`DELETE /api/partida/deletar/{id}`): partida não encontrada
+
+---
+
+## 4. Observações gerais e orientação para documentação futura
+
+- Sempre retorne os campos "codigoErro", "mensagem", "dataHora" e "errors" (quando aplicável).
+- Use erro apenas “representativo” nas anotações das controllers. Casos específicos de campos inválidos, erros de negócio etc, documente neste arquivo ou em Wiki.
+- Novos fluxos ou recursos devem seguir o mesmo padrão.
+- Em endpoints paginados, resposta vazia é considerada 200 OK com array vazio.
+- Mantenha os exemplos de erros padronizados para facilitar testes automatizados e integração de clientes.
+
+---

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/AtualizarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/AtualizarClubeApiController.java
@@ -37,18 +37,7 @@ public class AtualizarClubeApiController {
     @ApiResponse(
             responseCode = "200",
             description = "Clube atualizado com sucesso",
-            content = @Content(
-                    schema = @Schema(implementation = ClubeResponseDTO.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                  "nome":"Clube Atualizado",
-                  "siglaEstado":"AM",
-                  "dataCriacao":"2025-05-13"
-                }
-                """
-                    )
-            )
+            content = @Content(schema = @Schema(implementation = ClubeResponseDTO.class))
     )
     @ApiResponse(
             responseCode = "400",
@@ -88,6 +77,25 @@ public class AtualizarClubeApiController {
             )
     )
     @ApiResponse(
+            responseCode = "404",
+            description = "Clube não encontrado",
+            content = @Content(
+                    schema = @Schema(implementation = ErroPadrao.class),
+                    examples = @ExampleObject(
+                            name = "clube-nao-encontrado",
+                            summary = "Clube não existe na base de dados",
+                            value = """
+                {
+                    "codigoErro": "CLUBE_NAO_ENCONTRADO",
+                    "dataHora": "04/08/2025 11:52:23",
+                    "mensagem": "Clube com id 999 não encontrado.",
+                    "errors": null
+                }
+                """
+                    )
+            )
+    )
+    @ApiResponse(
             responseCode = "409",
             description = "Conflito de dados (data inválida ou duplicidade de clube)",
             content = @Content(
@@ -118,25 +126,6 @@ public class AtualizarClubeApiController {
                     """
                             )
                     }
-            )
-    )
-    @ApiResponse(
-            responseCode = "404",
-            description = "Clube não encontrado",
-            content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            name = "clube-nao-encontrado",
-                            summary = "Clube não existe na base de dados",
-                            value = """
-                {
-                    "codigoErro": "CLUBE_NAO_ENCONTRADO",
-                    "dataHora": "04/08/2025 11:52:23",
-                    "mensagem": "Clube com id 999 não encontrado.",
-                    "errors": null
-                }
-                """
-                    )
             )
     )
     @PutMapping("/{id}")

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/AtualizarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/AtualizarClubeApiController.java
@@ -44,36 +44,11 @@ public class AtualizarClubeApiController {
             description = "Campos inválidos ou estado inexistente",
             content = @Content(
                     schema = @Schema(implementation = ErroPadrao.class),
-                    examples = {
+                    examples =
                             @ExampleObject(
                                     name = "campos-invalidos",
-                                    summary = "Request com campos inválidos",
-                                    value = """
-                    {
-                        "codigoErro": "CAMPO_INVALIDO",
-                        "dataHora": "04/08/2025 11:02:56",
-                        "mensagem": "Invalid request content.",
-                        "errors": {
-                            "siglaEstado": "A sigla do estado só pode ter 2 letras.",
-                            "nome": "O nome tem que ter no minimo duas letras;",
-                            "dataCriacao": "A data de criação não pode ser futura"
-                        }
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "estado-inexistente",
-                                    summary = "Tentativa de atualizar clube com estado que não existe",
-                                    value = """
-                    {
-                        "codigoErro": "ESTADO_INEXISTENTE",
-                        "dataHora": "04/08/2025 11:03:40",
-                        "mensagem": "Não é possivel criar o clube pois o estado AX não existe.",
-                        "errors": null
-                    }
-                    """
+                                    summary = "Request com campos inválidos"
                             )
-                    }
             )
     )
     @ApiResponse(
@@ -83,15 +58,7 @@ public class AtualizarClubeApiController {
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             name = "clube-nao-encontrado",
-                            summary = "Clube não existe na base de dados",
-                            value = """
-                {
-                    "codigoErro": "CLUBE_NAO_ENCONTRADO",
-                    "dataHora": "04/08/2025 11:52:23",
-                    "mensagem": "Clube com id 999 não encontrado.",
-                    "errors": null
-                }
-                """
+                            summary = "Clube não existe na base de dados"
                     )
             )
     )
@@ -100,32 +67,11 @@ public class AtualizarClubeApiController {
             description = "Conflito de dados (data inválida ou duplicidade de clube)",
             content = @Content(
                     schema = @Schema(implementation = ErroPadrao.class),
-                    examples = {
+                    examples =
                             @ExampleObject(
                                     name = "data-criacao-posterior",
-                                    summary = "Data de criação após uma partida cadastrada",
-                                    value = """
-                    {
-                        "codigoErro": "DATA_CRIACAO_POSTERIOR_A_DATA_PARTIDA",
-                        "dataHora": "04/08/2025 11:52:08",
-                        "mensagem": "A data de criação do clube com id 1 está posterior a data de uma partida cadastrada.",
-                        "errors": null
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "clube-duplicado",
-                                    summary = "Nome duplicado para o mesmo estado",
-                                    value = """
-                    {
-                        "codigoErro": "CLUBE_DUPLICADO",
-                        "dataHora": "04/08/2025 11:04:33",
-                        "mensagem": "Já existe clube com este nome no mesmo estado.",
-                        "errors": null
-                    }
-                    """
+                                    summary = "Data de criação após uma partida cadastrada"
                             )
-                    }
             )
     )
     @PutMapping("/{id}")

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/BuscarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/BuscarClubeApiController.java
@@ -40,71 +40,10 @@ public class BuscarClubeApiController {
             description = "Lista paginada de clubes",
             content = @Content(
                     schema = @Schema(implementation = ClubeResponseDTO.class),
-                    examples = {@ExampleObject(
-                            name = "lista com resultados",
-                            summary = "Retorno de clubes encontrados",
-                            value = """
-                            {
-                        "content": [
-                                 {
-                                     "nome": "clube de time atualizado",
-                                     "siglaEstado": "AM",
-                                     "dataCriacao": "2025-05-13"
-                                 },
-                                 {
-                                     "nome": "clube de time",
-                                     "siglaEstado": "AP",
-                                     "dataCriacao": "2025-05-13"
-                                 }
-                             ],
-                             "pageable": {
-                                 "pageNumber": 0,
-                                 "pageSize": 20,
-                                 "sort": {
-                                     "empty": true,
-                                     "sorted": false,
-                                     "unsorted": true
-                                 },
-                                 "offset": 0,
-                                 "paged": true,
-                                 "unpaged": false
-                             },
-                             "last": true,
-                             "totalElements": 2,
-                             "totalPages": 1,
-                             "first": true,
-                             "size": 20,
-                             "number": 0,
-                             "sort": {
-                                 "empty": true,
-                                 "sorted": false,
-                                 "unsorted": true
-                             },
-                             "numberOfElements": 2,
-                             "empty": false
-                         }
-                        """
-
-                    ),
-                    @ExampleObject(
-                            name = "casoSemResultados",
-                            summary = "Retorno quando não encontra clubes para o filtro ou se não há clubes cadastrados.",
-                            value = """
-                            {
-                              "content": [],
-                              "pageable": { "pageNumber": 0, "pageSize": 20, ... },
-                              "last": true,
-                              "totalElements": 0,
-                              "totalPages": 0,
-                              "first": true,
-                              "size": 20,
-                              "number": 0,
-                              "sort": { "empty": true, "sorted": false, "unsorted": true },
-                              "numberOfElements": 0,
-                              "empty": true
-                            }
-                            """
-                    )}
+                    examples = @ExampleObject(
+                            name = "lista com resultados ou vazia",
+                            summary = "Retorno com lista de clubes encontrados ou lista vazia se clubes não existirem"
+                    )
             )
     )
     @GetMapping
@@ -132,33 +71,14 @@ public class BuscarClubeApiController {
             responseCode = "200",
             description = "Clube encontrado com sucesso",
             content = @Content(
-                    schema = @Schema(implementation = ClubeResponseDTO.class),
-                    examples = @ExampleObject(
-                            value = """
-            {
-              "nome": "clube de time atualizado",
-              "siglaEstado": "AM",
-              "dataCriacao": "2025-05-13"
-            }
-            """
-                    )
+                    schema = @Schema(implementation = ClubeResponseDTO.class)
             )
     )
     @ApiResponse(
             responseCode = "404",
             description = "Clube não encontrado",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            value = """
-            {
-              "codigoErro": "CLUBE_NAO_ENCONTRADO",
-              "dataHora": "04/08/2025 10:23:55",
-              "mensagem": "Clube com id 999 não encontrado.",
-              "errors": null
-            }
-            """
-                    )
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @GetMapping(value = "/{id}")

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/CriarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/CriarClubeApiController.java
@@ -30,7 +30,6 @@ public class CriarClubeApiController {
         this.criarClubeService = criarClubeService;
     }
 
-
     @Operation(
             summary = "Cria um novo clube",
             description = "Cadastra um novo clube. Retorna 201 ao sucesso."
@@ -39,16 +38,7 @@ public class CriarClubeApiController {
             responseCode = "201",
             description = "Clube criado com sucesso",
             content = @Content(
-                    schema = @Schema(implementation = ClubeResponseDTO.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                  "nome":"Clube de Exemplo dezoito",
-                  "siglaEstado":"AM",
-                  "dataCriacao":"2025-05-13"
-                }
-                """
-                    )
+                    schema = @Schema(implementation = ClubeResponseDTO.class)
             )
     )
     @ApiResponse(
@@ -56,53 +46,18 @@ public class CriarClubeApiController {
             description = "Campos inválidos ou estado inexistente",
             content = @Content(
                     schema = @Schema(implementation = ErroPadrao.class),
-                    examples = {
-                            @ExampleObject(
-                                    name = "campos-invalidos",
-                                    summary = "Request com campos inválidos",
-                                    value = """
-                {
-                    "codigoErro": "CAMPO_INVALIDO",
-                    "dataHora": "04/08/2025 11:02:56",
-                    "mensagem": "Invalid request content.",
-                    "errors": {
-                        "siglaEstado": "A sigla do estado só pode ter 2 letras.",
-                        "nome": "O nome tem que ter no minimo duas letras;",
-                        "dataCriacao": "A data de criação não pode ser futura"
-                    }
-                }
-                """
-                            ),
+                    examples =
                             @ExampleObject(
                                     name = "estado-inexistente",
-                                    summary = "Tentativa de criar clube com estado inexistente",
-                                    value = """
-                {
-                    "codigoErro": "ESTADO_INEXISTENTE",
-                    "dataHora": "04/08/2025 11:03:40",
-                    "mensagem": "Não é possivel criar o clube pois o estado AX não existe.",
-                    "errors": null
-                }
-                """
+                                    summary = "Tentativa de criar clube com estado inexistente"
                             )
-                    }
             )
     )
     @ApiResponse(
             responseCode = "409",
             description = "Já existe clube com esse nome no estado",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "codigoErro": "CLUBE_DUPLICADO",
-                    "dataHora": "04/08/2025 11:04:33",
-                    "mensagem": "Já existe clube com este nome no mesmo estado.",
-                    "errors": null
-                }
-                """
-                    )
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @PostMapping

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/InativarClubeApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/controller/InativarClubeApiController.java
@@ -42,15 +42,7 @@ public class InativarClubeApiController {
                     schema = @Schema(implementation = ErroPadrao.class),
                     examples = @ExampleObject(
                             name = "clube-nao-encontrado",
-                            summary = "Tentativa de inativar clube inexistente",
-                            value = """
-                {
-                    "codigoErro": "CLUBE_NAO_ENCONTRADO",
-                    "dataHora": "04/08/2025 12:00:00",
-                    "mensagem": "Clube com id 999 não encontrado.",
-                    "errors": null
-                }
-                """
+                            summary = "Tentativa de inativar clube inexistente"
                     )
             )
     )

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/rabbitmq/dto/ClubeEvent.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/rabbitmq/dto/ClubeEvent.java
@@ -1,8 +1,8 @@
 package br.com.meli.teamcubation_partidas_de_futebol.clube.rabbitmq.dto;
 
 import br.com.meli.teamcubation_partidas_de_futebol.clube.dto.CriarClubeRequestDTO;
-import br.com.meli.teamcubation_partidas_de_futebol.clube.rabbitmq.util.ClubeEventStatus;
-import br.com.meli.teamcubation_partidas_de_futebol.clube.rabbitmq.util.ClubeEventType;
+import br.com.meli.teamcubation_partidas_de_futebol.clube.rabbitmq.enums.ClubeEventStatus;
+import br.com.meli.teamcubation_partidas_de_futebol.clube.rabbitmq.enums.ClubeEventType;
 
 import java.time.LocalDateTime;
 

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/rabbitmq/enums/ClubeEventStatus.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/rabbitmq/enums/ClubeEventStatus.java
@@ -1,0 +1,8 @@
+package br.com.meli.teamcubation_partidas_de_futebol.clube.rabbitmq.enums;
+
+public enum ClubeEventStatus {
+    CREATED,
+    UPDATED,
+    DELETED,
+
+}

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/rabbitmq/enums/ClubeEventType.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/rabbitmq/enums/ClubeEventType.java
@@ -1,0 +1,7 @@
+package br.com.meli.teamcubation_partidas_de_futebol.clube.rabbitmq.enums;
+
+public enum ClubeEventType {
+    CRIACAO,
+    ATUALIZACAO,
+    EXCLUSAO
+}

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/rabbitmq/util/ClubeEventStatus.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/rabbitmq/util/ClubeEventStatus.java
@@ -1,8 +1,0 @@
-package br.com.meli.teamcubation_partidas_de_futebol.clube.rabbitmq.util;
-
-public enum ClubeEventStatus {
-    CREATED,
-    UPDATED,
-    DELETED,
-
-}

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/rabbitmq/util/ClubeEventType.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/clube/rabbitmq/util/ClubeEventType.java
@@ -1,7 +1,0 @@
-package br.com.meli.teamcubation_partidas_de_futebol.clube.rabbitmq.util;
-
-public enum ClubeEventType {
-    CRIACAO_CLUBE,
-    ATUALIZACAO_CLUBE,
-    EXCLUSAO_CLUBE
-}

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/AtualizarEstadioApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/AtualizarEstadioApiController.java
@@ -36,22 +36,7 @@ public class AtualizarEstadioApiController {
             responseCode = "200",
             description = "Estádio atualizado com sucesso",
             content = @Content(
-                    schema = @Schema(implementation = EstadioEnderecoResponseDTO.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "nome": "Estadio de time atualizado com cep meli",
-                    "endereco": {
-                        "cep": "88032-005",
-                        "logradouro": "Rodovia José Carlos Daux",
-                        "bairro": "Saco Grande",
-                        "localidade": "Florianópolis",
-                        "uf": "SC",
-                        "estado": "Santa Catarina"
-                    }
-                }
-                """
-                    )
+                    schema = @Schema(implementation = EstadioEnderecoResponseDTO.class)
             )
     )
     @ApiResponse(
@@ -59,87 +44,25 @@ public class AtualizarEstadioApiController {
             description = "Campos inválidos",
             content = @Content(
                     schema = @Schema(implementation = ErroPadrao.class),
-                    examples = {
+                    examples =
                             @ExampleObject(
-                                    name = "nomeInvalidoECepNulo",
-                                    summary = "Nome com menos de 3 letras, CEP nulo",
-                                    value = """
-                    {
-                        "codigoErro": "CAMPO_INVALIDO",
-                        "dataHora": "04/08/2025 16:17:13",
-                        "mensagem": "Invalid request content.",
-                        "errors": {
-                            "nome": "O nome tem que ter no minimo três letras",
-                            "cep": "não deve ser nulo"
-                        }
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "nomeInvalidoECepInvalido",
-                                    summary = "Nome com menos de 3 letras, CEP formato inválido",
-                                    value = """
-                    {
-                        "codigoErro": "CAMPO_INVALIDO",
-                        "dataHora": "04/08/2025 16:18:31",
-                        "mensagem": "Invalid request content.",
-                        "errors": {
-                            "nome": "O nome tem que ter no minimo três letras",
-                            "cep": "O cep deve conter exatamente 8 dígitos numéricos"
-                        }
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "nomeNuloECepInvalido",
-                                    summary = "Nome nulo, CEP formato inválido",
-                                    value = """
-                    {
-                        "codigoErro": "CAMPO_INVALIDO",
-                        "dataHora": "04/08/2025 16:18:54",
-                        "mensagem": "Invalid request content.",
-                        "errors": {
-                            "nome": "não deve ser nulo",
-                            "cep": "O cep deve conter exatamente 8 dígitos numéricos"
-                        }
-                    }
-                    """
+                                    name = "Nome e cep obrigatórios",
+                                    summary = "nome ou cep inválido/nulo"
+                                    )
                             )
-                    }
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Estádio não encontrado",
+            content = @Content(
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @ApiResponse(
             responseCode = "409",
             description = "Estádio com nome duplicado",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "codigoErro": "ESTADIO_JA_EXISTE",
-                    "dataHora": "04/08/2025 16:15:10",
-                    "mensagem": "Já existe um estadio com este nome.",
-                    "errors": null
-                }
-                """
-                    )
-            )
-    )
-    @ApiResponse(
-            responseCode = "404",
-            description = "Estádio não encontrado",
-            content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "codigoErro": "ESTADIO_NAO_ENCONTRADO",
-                    "dataHora": "04/08/2025 16:14:43",
-                    "mensagem": "Estadio com id 999 não encontrado.",
-                    "errors": null
-                }
-                """
-                    )
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @PutMapping(value = "/{id}")

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/BuscarEstadioApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/BuscarEstadioApiController.java
@@ -38,39 +38,14 @@ public class BuscarEstadioApiController {
             responseCode = "200",
             description = "Estádio encontrado",
             content = @Content(
-                    schema = @Schema(implementation = EstadioEnderecoResponseDTO.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "nome": "Estadio de time atualizado com cep meli",
-                    "endereco": {
-                        "cep": "88032-005",
-                        "logradouro": "Rodovia José Carlos Daux",
-                        "bairro": "Saco Grande",
-                        "localidade": "Florianópolis",
-                        "uf": "SC",
-                        "estado": "Santa Catarina"
-                    }
-                }
-                """
-                    )
+                    schema = @Schema(implementation = EstadioEnderecoResponseDTO.class)
             )
     )
     @ApiResponse(
             responseCode = "404",
             description = "Estádio não encontrado",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "codigoErro": "ESTADIO_NAO_ENCONTRADO",
-                    "dataHora": "04/08/2025 16:32:26",
-                    "mensagem": "Estadio com id 999 não encontrado.",
-                    "errors": null
-                }
-                """
-                    )
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @GetMapping(value = "/{id}")
@@ -90,65 +65,12 @@ public class BuscarEstadioApiController {
             description = "Lista paginada de estádios",
             content = @Content(
                     schema = @Schema(implementation = EstadioResponseDTO.class),
-                    examples = {
+                    examples =
                             @ExampleObject(
-                                    name = "comResultados",
-                                    summary = "Exemplo de lista com estádios encontrados",
-                                    value = """
-                    {
-                        "content": [
-                            { "nome": "Estadio de time atualizado com cep meli" },
-                            { "nome": "Estadio de time atualizado dois" },
-                            { "nome": "Estadio de time tres" }
-                        ],
-                        "pageable": {
-                            "pageNumber": 0,
-                            "pageSize": 20,
-                            "sort": { "empty": true, "sorted": false, "unsorted": true },
-                            "offset": 0,
-                            "paged": true,
-                            "unpaged": false
-                        },
-                        "last": true,
-                        "totalPages": 1,
-                        "totalElements": 11,
-                        "first": true,
-                        "size": 20,
-                        "number": 0,
-                        "sort": { "empty": true, "sorted": false, "unsorted": true },
-                        "numberOfElements": 11,
-                        "empty": false
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "vazio",
-                                    summary = "Exemplo de lista vazia (sem resultados para o filtro)",
-                                    value = """
-                    {
-                        "content": [],
-                        "pageable": {
-                            "pageNumber": 0,
-                            "pageSize": 20,
-                            "sort": { "empty": true, "sorted": false, "unsorted": true },
-                            "offset": 0,
-                            "paged": true,
-                            "unpaged": false
-                        },
-                        "last": true,
-                        "totalPages": 0,
-                        "totalElements": 0,
-                        "first": true,
-                        "size": 20,
-                        "number": 0,
-                        "sort": { "empty": true, "sorted": false, "unsorted": true },
-                        "numberOfElements": 0,
-                        "empty": true
-                    }
-                    """
+                                    name = "Com Resultados ou vazio",
+                                    summary = "Estádios encontrados ou lista vazia se não possuir estadios"
+                                    )
                             )
-                    }
-            )
     )
     @GetMapping
     public Page<EstadioResponseDTO> buscarTodosEstadiosFiltrados(

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/CriarEstadioApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/estadio/controller/CriarEstadioApiController.java
@@ -37,22 +37,7 @@ public class CriarEstadioApiController {
             responseCode = "201",
             description = "Estádio criado com sucesso",
             content = @Content(
-                    schema = @Schema(implementation = EstadioEnderecoResponseDTO.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "nome": "Arena Central",
-                    "endereco": {
-                        "cep": "88032-005",
-                        "logradouro": "Rodovia José Carlos Daux",
-                        "bairro": "Saco Grande",
-                        "localidade": "Florianópolis",
-                        "uf": "SC",
-                        "estado": "Santa Catarina"
-                    }
-                }
-                """
-                    )
+                    schema = @Schema(implementation = EstadioEnderecoResponseDTO.class)
             )
     )
     @ApiResponse(
@@ -60,70 +45,18 @@ public class CriarEstadioApiController {
             description = "Campos inválidos",
             content = @Content(
                     schema = @Schema(implementation = ErroPadrao.class),
-                    examples = {
+                    examples =
                             @ExampleObject(
-                                    name = "nomeInvalidoECepNulo",
-                                    summary = "Nome com menos de 3 letras, CEP nulo",
-                                    value = """
-                    {
-                        "codigoErro": "CAMPO_INVALIDO",
-                        "dataHora": "04/08/2025 16:17:13",
-                        "mensagem": "Invalid request content.",
-                        "errors": {
-                            "nome": "O nome tem que ter no minimo três letras",
-                            "cep": "não deve ser nulo"
-                        }
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "nomeInvalidoECepInvalido",
-                                    summary = "Nome com menos de 3 letras, CEP formato inválido",
-                                    value = """
-                    {
-                        "codigoErro": "CAMPO_INVALIDO",
-                        "dataHora": "04/08/2025 16:18:31",
-                        "mensagem": "Invalid request content.",
-                        "errors": {
-                            "nome": "O nome tem que ter no minimo três letras",
-                            "cep": "O cep deve conter exatamente 8 dígitos numéricos"
-                        }
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "nomeNuloECepInvalido",
-                                    summary = "Nome nulo, CEP formato inválido",
-                                    value = """
-                    {
-                        "codigoErro": "CAMPO_INVALIDO",
-                        "dataHora": "04/08/2025 16:18:54",
-                        "mensagem": "Invalid request content.",
-                        "errors": {
-                            "nome": "não deve ser nulo",
-                            "cep": "O cep deve conter exatamente 8 dígitos numéricos"
-                        }
-                    }
-                    """
+                                    name = "Nome e cep obrigatórios",
+                                    summary = "nome ou cep inválido/nulo"
+                                    )
                             )
-                    }
-            )
     )
     @ApiResponse(
             responseCode = "409",
             description = "Estádio com nome duplicado",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "codigoErro": "ESTADIO_JA_EXISTE",
-                    "dataHora": "04/08/2025 16:15:10",
-                    "mensagem": "Já existe um estadio com este nome.",
-                    "errors": null
-                }
-                """
-                    )
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @PostMapping

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/AtualizarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/AtualizarPartidaApiController.java
@@ -9,7 +9,6 @@ import br.com.meli.teamcubation_partidas_de_futebol.partida.service.AtualizarPar
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,169 +36,28 @@ public class AtualizarPartidaApiController {
             responseCode = "200",
             description = "Partida atualizada com sucesso",
             content = @Content(
-                    schema = @Schema(implementation = PartidaResponseDTO.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "clubeMandante": {
-                        "nome": "clube de time atualizado",
-                        "siglaEstado": "AM",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "clubeVisitante": {
-                        "nome": "clube de time",
-                        "siglaEstado": "AP",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "estadio": {
-                        "nome": "Estadio de time atualizado com cep meli"
-                    },
-                    "golsMandante": 2,
-                    "golsVisitante": 2,
-                    "dataHora": "10/06/2025 21:00:00",
-                    "resultado": "EMPATE"
-                }
-                """
-                    )
+                    schema = @Schema(implementation = PartidaResponseDTO.class)
             )
     )
     @ApiResponse(
             responseCode = "400",
             description = "Dados inválidos, clubes iguais, clubes/estádio inexistentes, gols negativos ou data futura",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = {
-                            @ExampleObject(
-                                    name = "campos-invalidos",
-                                    summary = "Gols negativos e data futura",
-                                    value = """
-                    {
-                        "codigoErro": "CAMPO_INVALIDO",
-                        "dataHora": "04/08/2025 19:14:14",
-                        "mensagem": "Invalid request content.",
-                        "errors": {
-                            "golsMandante": "O número de gols do mandante não pode ser negativo",
-                            "golsVisitante": "O número de gols do visitante não pode ser negativo",
-                            "dataHora": "A data da partida não pode ser futura"
-                        }
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "clubes-iguais",
-                                    summary = "Clubes mandante e visitante iguais",
-                                    value = """
-                    {
-                        "codigoErro": "CLUBES_IGUAIS",
-                        "dataHora": "04/08/2025 19:14:29",
-                        "mensagem": "Não é possivel criar a partida pois os clubes são iguais.",
-                        "errors": null
-                    }
-                    """
-                            )
-                    }
-            )
-    )
-    @ApiResponse(
-            responseCode = "409",
-            description = "Conflitos de regras de negócio: datas, clube inativo, partidas próximas, estádio já ocupado",
-            content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = {
-                            @ExampleObject(
-                                    name = "data-antes-criacao-clube",
-                                    summary = "Data da partida anterior à criação de clube",
-                                    value = """
-                    {
-                        "codigoErro": "DATA_PARTIDA_ANTERIOR_A_CRIACAO_DO_CLUBE",
-                        "dataHora": "04/08/2025 19:14:42",
-                        "mensagem": "Não pode cadastrar uma partida para uma data anterior à data de criação do clube.",
-                        "errors": null
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "clube-inativo",
-                                    summary = "Clube envolvido está inativo",
-                                    value = """
-                    {
-                        "codigoErro": "CLUBE_INATIVO",
-                        "dataHora": "04/08/2025 19:15:02",
-                        "mensagem": "Não é possivel criar a partida pois há um clube inativo",
-                        "errors": null
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "partidas-menor-48h",
-                                    summary = "Clube com outras partidas em menos de 48h",
-                                    value = """
-                    {
-                        "codigoErro": "CLUBE_TEM_PARTIDAS_COM_DATA_MENOR_QUE_48_HORAS_DA_NOVA_PARTIDA",
-                        "dataHora": "04/08/2025 19:17:18",
-                        "mensagem": "Não é possível criar a partida pois um dos clubes já possui uma partida cadastrada em menos de 48 horas desta data.",
-                        "errors": null
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "estadio-ja-tem-partida-no-dia",
-                                    summary = "Estádio já possui partida marcada para o mesmo dia",
-                                    value = """
-                    {
-                        "codigoErro": "ESTADIO_JA_POSSUI_PARTIDA_MARCADA_NO_MESMO_DIA",
-                        "dataHora": "04/08/2025 19:25:18",
-                        "mensagem": "Não é possivel criar a partida pois no estádio já tem uma partida marcada para o mesmo dia",
-                        "errors": null
-                    }
-                    """
-                            )
-                    }
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @ApiResponse(
             responseCode = "404",
             description = "Clube, estádio ou partida não encontrada",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = {
-                            @ExampleObject(
-                                    name = "clube-nao-encontrado",
-                                    summary = "Clube não encontrado",
-                                    value = """
-                {
-                    "codigoErro": "CLUBE_NAO_ENCONTRADO",
-                    "dataHora": "04/08/2025 19:27:34",
-                    "mensagem": "Clube com id 999 não encontrado.",
-                    "errors": null
-                }
-                """
-                            ),
-                            @ExampleObject(
-                                    name = "estadio-nao-encontrado",
-                                    summary = "Estádio não encontrado",
-                                    value = """
-                {
-                    "codigoErro": "ESTADIO_NAO_ENCONTRADO",
-                    "dataHora": "04/08/2025 19:28:03",
-                    "mensagem": "Estadio com id 999 não encontrado.",
-                    "errors": null
-                }
-                """
-                            ),
-                            @ExampleObject(
-                                    name = "partida-nao-encontrada",
-                                    summary = "Partida não encontrada",
-                                    value = """
-                {
-                    "codigoErro": "PARTIDA_NAO_ENCONTRADA",
-                    "dataHora": "04/08/2025 19:29:10",
-                    "mensagem": "Partida com id 999 não encontrada.",
-                    "errors": null
-                }
-                """
-                            )
-                    }
+                    schema = @Schema(implementation = ErroPadrao.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "409",
+            description = "Conflitos de regras de negócio: datas, clube inativo, partidas próximas, estádio já ocupado",
+            content = @Content(
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @PutMapping(value = "/{id}")

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/BuscarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/BuscarPartidaApiController.java
@@ -39,47 +39,14 @@ public class BuscarPartidaApiController {
             responseCode = "200",
             description = "Partida encontrada com sucesso",
             content = @Content(
-                    schema = @Schema(implementation = PartidaResponseDTO.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "clubeMandante": {
-                        "nome": "Clube Mandante",
-                        "siglaEstado": "AM",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "clubeVisitante": {
-                        "nome": "Clube Visitante",
-                        "siglaEstado": "AP",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "estadio": {
-                        "nome": "Estadio Exemplo"
-                    },
-                    "golsMandante": 2,
-                    "golsVisitante": 1,
-                    "dataHora": "10/06/2025 21:00:00",
-                    "resultado": "VITORIA_MANDANTE"
-                }
-                """
-                    )
+                    schema = @Schema(implementation = PartidaResponseDTO.class)
             )
     )
     @ApiResponse(
             responseCode = "404",
             description = "Partida não encontrada",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "codigoErro": "PARTIDA_NAO_ENCONTRADA",
-                    "dataHora": "04/08/2025 23:30:00",
-                    "mensagem": "Partida com id 999 não encontrada.",
-                    "errors": null
-                }
-                """
-                    )
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @GetMapping(value = "/{id}")
@@ -99,96 +66,11 @@ public class BuscarPartidaApiController {
             description = "Lista paginada de partidas",
             content = @Content(
                     schema = @Schema(implementation = PartidaResponseDTO.class),
-                    examples = {
+                    examples =
                             @ExampleObject(
-                                    name = "lista-com-resultados",
-                                    summary = "Partidas encontradas",
-                                    value = """
-                    {
-                        "content": [
-                            {
-                                "clubeMandante": {
-                                    "nome": "Clube Mandante",
-                                    "siglaEstado": "AM",
-                                    "dataCriacao": "2025-05-13"
-                                },
-                                "clubeVisitante": {
-                                    "nome": "Clube Visitante",
-                                    "siglaEstado": "AP",
-                                    "dataCriacao": "2025-05-13"
-                                },
-                                "estadio": {
-                                    "nome": "Estadio Exemplo"
-                                },
-                                "golsMandante": 2,
-                                "golsVisitante": 1,
-                                "dataHora": "10/06/2025 21:00:00",
-                                "resultado": "VITORIA_MANDANTE"
-                            }
-                        ],
-                        "pageable": {
-                            "pageNumber": 0,
-                            "pageSize": 20,
-                            "sort": {
-                                "empty": true,
-                                "sorted": false,
-                                "unsorted": true
-                            },
-                            "offset": 0,
-                            "paged": true,
-                            "unpaged": false
-                        },
-                        "last": true,
-                        "totalElements": 1,
-                        "totalPages": 1,
-                        "first": true,
-                        "size": 20,
-                        "number": 0,
-                        "sort": {
-                            "empty": true,
-                            "sorted": false,
-                            "unsorted": true
-                        },
-                        "numberOfElements": 1,
-                        "empty": false
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "lista-vazia",
-                                    summary = "Nenhuma partida encontrada para os filtros",
-                                    value = """
-                    {
-                        "content": [],
-                        "pageable": {
-                            "pageNumber": 0,
-                            "pageSize": 20,
-                            "sort": {
-                                "empty": true,
-                                "sorted": false,
-                                "unsorted": true
-                            },
-                            "offset": 0,
-                            "paged": true,
-                            "unpaged": false
-                        },
-                        "last": true,
-                        "totalElements": 0,
-                        "totalPages": 0,
-                        "first": true,
-                        "size": 20,
-                        "number": 0,
-                        "sort": {
-                            "empty": true,
-                            "sorted": false,
-                            "unsorted": true
-                        },
-                        "numberOfElements": 0,
-                        "empty": true
-                    }
-                    """
-                            )
-                    }
+                                    name = "lista com resultados ou vazia",
+                                    summary = "Lista de partidas encontradas ou lista vazia se partidas não existirem"
+                    )
             )
     )
     @GetMapping

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/CriarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/CriarPartidaApiController.java
@@ -8,7 +8,6 @@ import br.com.meli.teamcubation_partidas_de_futebol.partida.model.Partida;
 import br.com.meli.teamcubation_partidas_de_futebol.partida.service.CriarPartidaService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -39,157 +38,28 @@ public class CriarPartidaApiController {
             responseCode = "201",
             description = "Partida criada com sucesso",
             content = @Content(
-                    schema = @Schema(implementation = PartidaResponseDTO.class),
-                    examples = @ExampleObject(
-                            value = """
-                {
-                    "clubeMandante": {
-                        "nome": "clube de time criado",
-                        "siglaEstado": "AM",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "clubeVisitante": {
-                        "nome": "clube de time dois",
-                        "siglaEstado": "AP",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "estadio": {
-                        "nome": "Estadio Exemplo"
-                    },
-                    "golsMandante": 2,
-                    "golsVisitante": 1,
-                    "dataHora": "10/06/2025 21:00:00",
-                    "resultado": "VITORIA_MANDANTE"
-                }
-                """
-                    )
+                    schema = @Schema(implementation = PartidaResponseDTO.class)
             )
     )
     @ApiResponse(
             responseCode = "400",
             description = "Dados inválidos (campos obrigatórios, gols negativos, data futura, clubes iguais)",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = {
-                            @ExampleObject(
-                                    name = "campos-invalidos",
-                                    summary = "Campos obrigatórios não informados ou inválidos",
-                                    value = """
-                    {
-                        "codigoErro": "CAMPO_INVALIDO",
-                        "dataHora": "04/08/2025 22:31:14",
-                        "mensagem": "Invalid request content.",
-                        "errors": {
-                            "golsMandante": "O número de gols do mandante não pode ser negativo",
-                            "golsVisitante": "O número de gols do visitante não pode ser negativo",
-                            "dataHora": "A data da partida não pode ser futura"
-                        }
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "clubes-iguais",
-                                    summary = "Clubes mandante e visitante iguais",
-                                    value = """
-                    {
-                        "codigoErro": "CLUBES_IGUAIS",
-                        "dataHora": "04/08/2025 22:32:29",
-                        "mensagem": "Não é possível criar partida pois os clubes são iguais.",
-                        "errors": null
-                    }
-                    """
-                            )
-                    }
-            )
-    )
-    @ApiResponse(
-            responseCode = "409",
-            description = "Conflitos de negócio: data anterior à criação de clube, clube inativo, partidas próximas, estádio já ocupado",
-            content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = {
-                            @ExampleObject(
-                                    name = "data-antes-criacao-clube",
-                                    summary = "Data da partida anterior à criação de clube",
-                                    value = """
-                    {
-                        "codigoErro": "DATA_PARTIDA_ANTERIOR_A_CRIACAO_DO_CLUBE",
-                        "dataHora": "04/08/2025 22:37:22",
-                        "mensagem": "Não pode cadastrar uma partida para uma data anterior à data de criação do clube.",
-                        "errors": null
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "clube-inativo",
-                                    summary = "Clube envolvido está inativo",
-                                    value = """
-                    {
-                        "codigoErro": "CLUBE_INATIVO",
-                        "dataHora": "04/08/2025 22:38:08",
-                        "mensagem": "Não é possível criar a partida pois há um clube inativo.",
-                        "errors": null
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "partidas-menor-48h",
-                                    summary = "Clube com outras partidas em menos de 48h",
-                                    value = """
-                    {
-                        "codigoErro": "CLUBE_TEM_PARTIDAS_COM_DATA_MENOR_QUE_48_HORAS_DA_NOVA_PARTIDA",
-                        "dataHora": "04/08/2025 22:39:10",
-                        "mensagem": "Não é possível criar a partida pois um dos clubes já possui uma partida cadastrada em menos de 48 horas desta data.",
-                        "errors": null
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "estadio-ja-tem-partida-no-dia",
-                                    summary = "Estádio já possui partida marcada para o mesmo dia",
-                                    value = """
-                    {
-                        "codigoErro": "ESTADIO_JA_POSSUI_PARTIDA_MARCADA_NO_MESMO_DIA",
-                        "dataHora": "04/08/2025 22:40:24",
-                        "mensagem": "Não é possível criar a partida pois no estádio já tem uma partida marcada para o mesmo dia.",
-                        "errors": null
-                    }
-                    """
-                            )
-                    }
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @ApiResponse(
             responseCode = "404",
             description = "Clube ou estádio não encontrado",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = {
-                            @ExampleObject(
-                                    name = "clube-nao-encontrado",
-                                    summary = "Clube não encontrado",
-                                    value = """
-                    {
-                        "codigoErro": "CLUBE_NAO_ENCONTRADO",
-                        "dataHora": "04/08/2025 19:27:34",
-                        "mensagem": "Clube com id 999 não encontrado.",
-                        "errors": null
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "estadio-nao-encontrado",
-                                    summary = "Estádio não encontrado",
-                                    value = """
-                    {
-                        "codigoErro": "ESTADIO_NAO_ENCONTRADO",
-                        "dataHora": "04/08/2025 19:28:03",
-                        "mensagem": "Estádio com id 999 não encontrado.",
-                        "errors": null
-                    }
-                    """
-                            )
-                    }
+                    schema = @Schema(implementation = ErroPadrao.class)
+            )
+    )
+    @ApiResponse(
+            responseCode = "409",
+            description = "Conflitos de negócio: data anterior à criação de clube, clube inativo, partidas próximas, estádio já ocupado",
+            content = @Content(
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @PostMapping

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/DeletarPartidaApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/partida/controller/DeletarPartidaApiController.java
@@ -5,7 +5,6 @@ import br.com.meli.teamcubation_partidas_de_futebol.partida.service.DeletarParti
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -39,19 +38,7 @@ public class DeletarPartidaApiController {
             responseCode = "404",
             description = "Partida não encontrada",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            name = "partida-nao-encontrada",
-                            summary = "Partida não encontrada",
-                            value = """
-            {
-                "codigoErro": "PARTIDA_NAO_ENCONTRADA",
-                "dataHora": "04/08/2025 23:05:00",
-                "mensagem": "Partida com id 999 não encontrada.",
-                "errors": null
-            }
-            """
-                    )
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @DeleteMapping(value = "/{id}")

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/ranking/controller/RankingApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/ranking/controller/RankingApiController.java
@@ -5,7 +5,6 @@ import br.com.meli.teamcubation_partidas_de_futebol.ranking.service.RankingServi
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -37,73 +36,14 @@ public class RankingApiController {
         - TOTAL_VITORIAS
         - TOTAL_GOLS
         - TOTAL_JOGOS
-        - Uma lista vazia é retornada caso não existam clubes para o ranking solicitado.
+        - Uma lista vazia é retornada caso não existam clubes e partidas para o ranking solicitado.
         """
     )
     @ApiResponse(
             responseCode = "200",
-            description = "Ranking retornado com sucesso",
+            description = "Lista de Ranking retornado, lista vazia se clubes estiverem com pontuação zerada ou não existirem partidas",
             content = @Content(
-                    schema = @Schema(implementation = Ranking.class),
-                    examples = {
-                            @ExampleObject(
-                                    name = "TOTAL_PONTOS",
-                                    summary = "Ranking por total de pontos",
-                                    value = """
-                    [
-                        {"nomeClube": "aclube de time", "estadoClube": "AP", "total": 6},
-                        {"nomeClube": "clube de time criado", "estadoClube": "SP", "total": 6},
-                        {"nomeClube": "Clube de Exemplo Um", "estadoClube": "AM", "total": 6},
-                        {"nomeClube": "time teste", "estadoClube": "SP", "total": 5},
-                        {"nomeClube": "clube de time atualizado", "estadoClube": "AM", "total": 4}
-                    ]
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "TOTAL_VITORIAS",
-                                    summary = "Ranking por total de vitórias",
-                                    value = """
-                    [
-                        {"nomeClube": "aclube de time", "estadoClube": "AP", "total": 2},
-                        {"nomeClube": "clube de time criado", "estadoClube": "SP", "total": 2},
-                        {"nomeClube": "Clube de Exemplo Um", "estadoClube": "AM", "total": 2},
-                        {"nomeClube": "clube de time atualizado", "estadoClube": "AM", "total": 1},
-                        {"nomeClube": "clube de time criado", "estadoClube": "SC", "total": 1}
-                    ]
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "TOTAL_GOLS",
-                                    summary = "Ranking por total de gols",
-                                    value = """
-                    [
-                        {"nomeClube": "aclube de time", "estadoClube": "AP", "total": 10},
-                        {"nomeClube": "time teste", "estadoClube": "SP", "total": 8},
-                        {"nomeClube": "clube de time criado", "estadoClube": "SP", "total": 7},
-                        {"nomeClube": "Clube de Exemplo Um", "estadoClube": "AM", "total": 7},
-                        {"nomeClube": "clube de time atualizado", "estadoClube": "AM", "total": 6}
-                    ]
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "TOTAL_JOGOS",
-                                    summary = "Ranking por total de jogos",
-                                    value = """
-                    [
-                        {"nomeClube": "clube de time atualizado", "estadoClube": "AM", "total": 4},
-                        {"nomeClube": "aclube de time", "estadoClube": "AP", "total": 4},
-                        {"nomeClube": "clube de time", "estadoClube": "AP", "total": 3},
-                        {"nomeClube": "time teste", "estadoClube": "SP", "total": 3},
-                        {"nomeClube": "clube de time criado", "estadoClube": "SP", "total": 2}
-                    ]
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "lista-vazia",
-                                    summary = "Nenhum clube atende ao critério",
-                                    value = "[]"
-                            )
-                    }
+                    schema = @Schema(implementation = Ranking.class)
             )
     )
     @GetMapping

--- a/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/controller/BuscarRetrospectoApiController.java
+++ b/partidas-de-futebol-api/src/main/java/br/com/meli/teamcubation_partidas_de_futebol/retrospecto/controller/BuscarRetrospectoApiController.java
@@ -8,7 +8,6 @@ import br.com.meli.teamcubation_partidas_de_futebol.retrospecto.service.BuscarRe
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,64 +34,14 @@ public class BuscarRetrospectoApiController {
             responseCode = "200",
             description = "Retrospecto retornado com sucesso",
             content = @Content(
-                    schema = @Schema(implementation = Retrospecto.class),
-                    examples = {
-                            @ExampleObject(
-                                    name = "com-jogos",
-                                    summary = "Clube com partidas registradas",
-                                    value = """
-                    {
-                        "clube": {
-                            "nome": "clube de time atualizado",
-                            "siglaEstado": "AM",
-                            "dataCriacao": "2025-05-13"
-                        },
-                        "jogos": 4,
-                        "vitorias": 1,
-                        "derrotas": 2,
-                        "empates": 1,
-                        "golsFeitos": 6,
-                        "golsSofridos": 11
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "sem-jogos",
-                                    summary = "Clube sem partidas (todos campos zerados)",
-                                    value = """
-                    {
-                        "clube": {
-                            "nome": "clube de time quatro atualizado",
-                            "siglaEstado": "SP",
-                            "dataCriacao": "2025-05-13"
-                        },
-                        "jogos": 0,
-                        "vitorias": 0,
-                        "derrotas": 0,
-                        "empates": 0,
-                        "golsFeitos": 0,
-                        "golsSofridos": 0
-                    }
-                    """
-                            )
-                    }
+                    schema = @Schema(implementation = Retrospecto.class)
             )
     )
     @ApiResponse(
             responseCode = "404",
             description = "Clube não encontrado",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            value = """
-                    {
-                        "codigoErro": "CLUBE_NAO_ENCONTRADO",
-                        "dataHora": "05/08/2025 14:41:46",
-                        "mensagem": "Clube com id 999 não encontrado.",
-                        "errors": null
-                    }
-                    """
-                    )
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @GetMapping("/{id}/retrospecto")
@@ -117,79 +66,14 @@ public class BuscarRetrospectoApiController {
             responseCode = "200",
             description = "Retrospecto contra adversários retornado com sucesso",
             content = @Content(
-                    schema = @Schema(implementation = RetrospectoAdversariosResponseDTO.class),
-                    examples = {
-                            @ExampleObject(
-                                    name = "com-adversarios",
-                                    summary = "Lista de retrospectos para adversários",
-                                    value = """
-                    {
-                        "nomeClube": "clube de time atualizado",
-                        "estadoClube": "AM",
-                        "retrospectoContraAdversarios": [
-                            {
-                                "nomeAdversario": "aclube de time",
-                                "estadoAdversario": "AP",
-                                "jogos": 1,
-                                "vitorias": 0,
-                                "derrotas": 1,
-                                "empates": 0,
-                                "golsFeitos": 1,
-                                "golsSofridos": 4
-                            },
-                            {
-                                "nomeAdversario": "clube de time",
-                                "estadoAdversario": "AP",
-                                "jogos": 2,
-                                "vitorias": 1,
-                                "derrotas": 0,
-                                "empates": 1,
-                                "golsFeitos": 4,
-                                "golsSofridos": 3
-                            },
-                            {
-                                "nomeAdversario": "time teste",
-                                "estadoAdversario": "SP",
-                                "jogos": 1,
-                                "vitorias": 0,
-                                "derrotas": 1,
-                                "empates": 0,
-                                "golsFeitos": 1,
-                                "golsSofridos": 4
-                            }
-                        ]
-                    }
-                    """
-                            ),
-                            @ExampleObject(
-                                    name = "sem-adversarios",
-                                    summary = "Clube sem confrontos (lista vazia)",
-                                    value = """
-                    {
-                        "nomeClube": "clube de time quatro atualizado",
-                        "estadoClube": "SP",
-                        "retrospectoContraAdversarios": []
-                    }
-                    """
-                            )
-                    }
+                    schema = @Schema(implementation = RetrospectoAdversariosResponseDTO.class)
             )
     )
     @ApiResponse(
             responseCode = "404",
             description = "Clube não encontrado",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            value = """
-                    {
-                        "codigoErro": "CLUBE_NAO_ENCONTRADO",
-                        "dataHora": "05/08/2025 14:51:33",
-                        "mensagem": "Clube com id 999 não encontrado.",
-                        "errors": null
-                    }
-                    """
-                    )
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @GetMapping("/{id}/retrospectos-adversarios")
@@ -217,139 +101,14 @@ public class BuscarRetrospectoApiController {
             responseCode = "200",
             description = "Confronto encontrado ou ambos clubes com retrospecto zerado",
             content = @Content(
-                    schema = @Schema(implementation = RetrospectoConfronto.class),
-                    examples = {
-                            @ExampleObject(
-                                    name = "com-partidas",
-                                    summary = "Retrospecto com confrontos",
-                                    value = """
-        {
-            "retrospectos": [
-                {
-                    "clube": {
-                        "nome": "clube de time atualizado",
-                        "siglaEstado": "AM",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "jogos": 2,
-                    "vitorias": 1,
-                    "derrotas": 0,
-                    "empates": 1,
-                    "golsFeitos": 4,
-                    "golsSofridos": 3
-                },
-                {
-                    "clube": {
-                        "nome": "clube de time",
-                        "siglaEstado": "AP",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "jogos": 2,
-                    "vitorias": 0,
-                    "derrotas": 1,
-                    "empates": 1,
-                    "golsFeitos": 3,
-                    "golsSofridos": 4
-                }
-            ],
-            "partidas": [
-                {
-                    "clubeMandante": {
-                        "nome": "clube de time atualizado",
-                        "siglaEstado": "AM",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "clubeVisitante": {
-                        "nome": "clube de time",
-                        "siglaEstado": "AP",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "estadio": {
-                        "nome": "Estadio de time atualizado com cep meli"
-                    },
-                    "golsMandante": 1,
-                    "golsVisitante": 1,
-                    "dataHora": "04/08/2025 18:35:13",
-                    "resultado": "EMPATE"
-                },
-                {
-                    "clubeMandante": {
-                        "nome": "clube de time atualizado",
-                        "siglaEstado": "AM",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "clubeVisitante": {
-                        "nome": "clube de time",
-                        "siglaEstado": "AP",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "estadio": {
-                        "nome": "Estadio de time atualizado com cep meli"
-                    },
-                    "golsMandante": 3,
-                    "golsVisitante": 2,
-                    "dataHora": "05/06/2025 21:00:00",
-                    "resultado": "VITORIA_MANDANTE"
-                }
-            ]
-        }
-        """
-                            ),
-                            @ExampleObject(
-                                    name = "sem-partidas",
-                                    summary = "Não existe confronto, ambos clubes e retrospectos zerados",
-                                    value = """
-        {
-            "retrospectos": [
-                {
-                    "clube": {
-                        "nome": "clube de time atualizado",
-                        "siglaEstado": "AM",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "jogos": 0,
-                    "vitorias": 0,
-                    "derrotas": 0,
-                    "empates": 0,
-                    "golsFeitos": 0,
-                    "golsSofridos": 0
-                },
-                {
-                    "clube": {
-                        "nome": "clube de time quatro atualizado",
-                        "siglaEstado": "SP",
-                        "dataCriacao": "2025-05-13"
-                    },
-                    "jogos": 0,
-                    "vitorias": 0,
-                    "derrotas": 0,
-                    "empates": 0,
-                    "golsFeitos": 0,
-                    "golsSofridos": 0
-                }
-            ],
-            "partidas": []
-        }
-        """
-                            )
-                    }
+                    schema = @Schema(implementation = RetrospectoConfronto.class)
             )
     )
     @ApiResponse(
             responseCode = "404",
             description = "Um dos clubes não encontrado",
             content = @Content(
-                    schema = @Schema(implementation = ErroPadrao.class),
-                    examples = @ExampleObject(
-                            value = """
-                    {
-                        "codigoErro": "CLUBE_NAO_ENCONTRADO",
-                        "dataHora": "05/08/2025 14:57:51",
-                        "mensagem": "Clube com id 999 não encontrado.",
-                        "errors": null
-                    }
-                    """
-                    )
+                    schema = @Schema(implementation = ErroPadrao.class)
             )
     )
     @GetMapping("/{idClube}/confronto/{idAdversario}")

--- a/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/controller/CriarClubeController.java
+++ b/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/controller/CriarClubeController.java
@@ -1,10 +1,7 @@
 package br.com.meli.partidas_de_futebol_mensageria.clube.controller;
 
-import br.com.meli.partidas_de_futebol_mensageria.clube.dto.ClubeEvent;
 import br.com.meli.partidas_de_futebol_mensageria.clube.dto.CriarClubeRequestDTO;
-import br.com.meli.partidas_de_futebol_mensageria.clube.producer.CriarClubeProducer;
-import br.com.meli.partidas_de_futebol_mensageria.clube.util.ClubeEventStatus;
-import br.com.meli.partidas_de_futebol_mensageria.clube.util.ClubeEventType;
+import br.com.meli.partidas_de_futebol_mensageria.clube.service.CriarClubeEventService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,31 +10,20 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
-
 @RestController
 @RequestMapping("/api/v1/clube")
 public class CriarClubeController {
 
-    private final CriarClubeProducer producer;
+    private final CriarClubeEventService eventService;
 
-    public CriarClubeController(CriarClubeProducer producer) {
-        this.producer = producer;
+    public CriarClubeController(CriarClubeEventService eventService) {
+        this.eventService = eventService;
     }
 
     @PostMapping("/criar")
     public ResponseEntity<String> criarClube(@RequestBody @Valid CriarClubeRequestDTO criarClubeRequestDTO) {
-        ClubeEvent event = new ClubeEvent();
-        event.setStatus(ClubeEventStatus.CREATED);
-        event.setTipoEvento(ClubeEventType.CRIACAO_CLUBE);
-        event.setMessage("Clube enviado para processamento");
-        event.setDataHoraEvento(LocalDateTime.now());
-        event.setClube(criarClubeRequestDTO);
-
-        producer.sendCriarClube(event);
-        return ResponseEntity
-                .status(HttpStatus.ACCEPTED)
-                .body("Clube enviado para o RabbitMQ");
+        eventService.processarCriacaoClube(criarClubeRequestDTO);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body("Clube enviado para o RabbitMQ");
     }
 
 }

--- a/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/dto/ClubeEvent.java
+++ b/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/dto/ClubeEvent.java
@@ -1,7 +1,7 @@
 package br.com.meli.partidas_de_futebol_mensageria.clube.dto;
 
-import br.com.meli.partidas_de_futebol_mensageria.clube.util.ClubeEventStatus;
-import br.com.meli.partidas_de_futebol_mensageria.clube.util.ClubeEventType;
+import br.com.meli.partidas_de_futebol_mensageria.clube.enums.ClubeEventStatus;
+import br.com.meli.partidas_de_futebol_mensageria.clube.enums.ClubeEventType;
 
 import java.time.LocalDateTime;
 

--- a/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/enums/ClubeEventStatus.java
+++ b/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/enums/ClubeEventStatus.java
@@ -1,4 +1,4 @@
-package br.com.meli.partidas_de_futebol_mensageria.clube.util;
+package br.com.meli.partidas_de_futebol_mensageria.clube.enums;
 
 public enum ClubeEventStatus {
     CREATED,

--- a/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/enums/ClubeEventType.java
+++ b/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/enums/ClubeEventType.java
@@ -1,0 +1,7 @@
+package br.com.meli.partidas_de_futebol_mensageria.clube.enums;
+
+public enum ClubeEventType {
+    CRIACAO,
+    ATUALIZACAO,
+    EXCLUSAO
+}

--- a/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/producer/CriarClubeProducer.java
+++ b/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/producer/CriarClubeProducer.java
@@ -24,8 +24,8 @@ public class CriarClubeProducer {
         this.rabbitTemplate = rabbitTemplate;
     }
 
-    public void sendCriarClube(ClubeEvent clubeEvent) {
-        LOGGER.info("Clube event enviado para o RabbitMQ: {}", clubeEvent.toString());
-        rabbitTemplate.convertAndSend(exchangeClube, criarClubeRoutingKey, clubeEvent);
+    public void sendCriarClube(ClubeEvent event) {
+        LOGGER.info("Clube event enviado para o RabbitMQ: {}", event);
+        rabbitTemplate.convertAndSend(exchangeClube, criarClubeRoutingKey, event);
     }
 }

--- a/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/service/CriarClubeEventService.java
+++ b/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/service/CriarClubeEventService.java
@@ -1,0 +1,30 @@
+package br.com.meli.partidas_de_futebol_mensageria.clube.service;
+
+import br.com.meli.partidas_de_futebol_mensageria.clube.dto.ClubeEvent;
+import br.com.meli.partidas_de_futebol_mensageria.clube.dto.CriarClubeRequestDTO;
+import br.com.meli.partidas_de_futebol_mensageria.clube.enums.ClubeEventStatus;
+import br.com.meli.partidas_de_futebol_mensageria.clube.enums.ClubeEventType;
+import br.com.meli.partidas_de_futebol_mensageria.clube.producer.CriarClubeProducer;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+public class CriarClubeEventService {
+    private final CriarClubeProducer criarClubeProducer;
+
+    public CriarClubeEventService(CriarClubeProducer criarClubeProducer) {
+        this.criarClubeProducer = criarClubeProducer;
+    }
+
+    public void processarCriacaoClube(CriarClubeRequestDTO dto) {
+        ClubeEvent event = new ClubeEvent();
+        event.setStatus(ClubeEventStatus.CREATED);
+        event.setTipoEvento(ClubeEventType.CRIACAO);
+        event.setMessage("Clube enviado para processamento");
+        event.setDataHoraEvento(LocalDateTime.now());
+        event.setClube(dto);
+
+        criarClubeProducer.sendCriarClube(event);
+    }
+}

--- a/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/util/ClubeEventType.java
+++ b/partidas-de-futebol-mensageria/src/main/java/br/com/meli/partidas_de_futebol_mensageria/clube/util/ClubeEventType.java
@@ -1,7 +1,0 @@
-package br.com.meli.partidas_de_futebol_mensageria.clube.util;
-
-public enum ClubeEventType {
-    CRIACAO_CLUBE,
-    ATUALIZACAO_CLUBE,
-    EXCLUSAO_CLUBE
-}


### PR DESCRIPTION
Checklist do que foi solicitado **e** realizado
---

### Checklist do que foi solicitado

- [x] **Não produzir/enviar mensagens para o RabbitMQ direto na Controller**
    - Criada camada de service intermediária (`CriarClubeEventService`) para orquestrar montagem do evento e envio ao producer. Controller agora delega apenas à service.
- [x] **Renomear o pacote util para enums**
    - Pacote foi renomeado de `util` para `enums`, refletindo corretamente seu conteúdo apenas com tipos enum.
- [x] **ClubeEventType sem sufixo redundante**
    - Enum `ClubeEventType` foi reescrito para usar apenas os nomes `CRIACAO, ATUALIZACAO, EXCLUSAO`, removendo redundância (antes: `CRIACAO_CLUBE` etc).
- [x] **AtualizarClubeApiController – Swagger**
    - Substituído JSON explícito por uso do DTO em `@Schema`, eliminando poluição visual.
    - Responses documentadas em ordem crescente (200, 400, 404, 409).
    - Mantido apenas um exemplo por erro relevante (400, 404, 409); respostas de erro exaustivas removidas dos exemplos do Swagger e documentadas apenas na documentação técnica externa.
- [x] **BuscarClubeApiController – Swagger**
    - Documentada apenas a resposta 2xx de sucesso, com exemplo de caso feliz.
    - Removidas variações/exemplos desnecessários de casos alternativos/erro do Swagger; tais variações agora migradas para documentação técnica.

---

### Checklist de ações **extras** realizadas além das solicitações

- [x] **Documentação técnica de erros centralizada**
    - Criada documentação técnica (`api-erros-rest.md`) detalhando todos os códigos e exemplos de payload dos erros, cobrindo todos os domínios (Clubes, Estádios, Partidas) seguindo padrão padronizado de payload de erro.
- [x] **Padronização nas controllers de todos domínios**
    - Aplicado mesmo padrão Swagger nas demais controllers (Estádio, Partida, etc): ordenação das responses, remoção de múltiplos exemplos, uso só do DTO correspondente, apenas um exemplo para cada erro relevante.
- [x] **Padronização em responses paginadas**
    - Mantido apenas o DTO do item no `@Schema`, usando exemplos reais para ilustrar o Page-like(usando a própria consulta do swagger para ver o retorno paginado).
---